### PR TITLE
Add macos specific command key combo - Alt+Command+A

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -43,7 +43,8 @@
 	"commands": {
 		"get-talon-request": {
 			"suggested_key": {
-				"default": "Alt+Shift+A"
+				"default": "Alt+Shift+A",
+				"mac": "Alt+Command+A"
 			},
 			"description": "Give the signal to the native app to get the request"
 		}


### PR DESCRIPTION
The default one types the literal Å character and breaks direct clicking
when focussed on input fields.

This partially addresses https://github.com/david-tejada/rango/issues/14
