### PR TITLE
Update UpdateRangoVersion.swift script to use new Safari build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ workspace.code-workspace
 # macos metadata file
 .DS_Store
 # Xcode
+RangoVersion.xcconfig
 xcuserdata
 # Emacs
 *~

--- a/Rango/Build/UpdateRangoVersion.swift
+++ b/Rango/Build/UpdateRangoVersion.swift
@@ -18,7 +18,7 @@ let PROJECT_DIR = FilePath(CommandLine.arguments[0])
 
 let manifestPath = PROJECT_DIR
     .appending("..")
-    .appending("dist-mv2")
+    .appending("dist-mv2-safari")
     .appending("manifest.json")
     .string
 


### PR DESCRIPTION
It was looking in dist-mv2, not dist-mv2-safari, for the Rango web extension version.