### PR TITLE
Add command to enable hints with shortcut

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -4,6 +4,7 @@ import { toggleHintsGlobal, updateHintsToggle } from "./actions/toggleHints";
 import { toggleKeyboardClicking } from "./actions/toggleKeyboardClicking";
 import { handleRequestFromTalon } from "./messaging/handleRequestFromTalon";
 import { handleRequestFromContent } from "./messaging/handleRequestFromContent";
+import { sendRequestToContent } from "./messaging/sendRequestToContent";
 
 (async () => {
 	await initBackgroundScript();
@@ -18,6 +19,12 @@ browser.runtime.onMessage.addListener(handleRequestFromContent);
 });
 
 browser.commands.onCommand.addListener(async (internalCommand: string) => {
+	try {
+		await sendRequestToContent({ type: "allowToastNotification" });
+	} catch {
+		// No content script. We do nothing.
+	}
+
 	if (
 		internalCommand === "get-talon-request" ||
 		internalCommand === "get-talon-request-alternative"
@@ -31,6 +38,10 @@ browser.commands.onCommand.addListener(async (internalCommand: string) => {
 
 	if (internalCommand === "disable-hints") {
 		await updateHintsToggle("global", false);
+	}
+
+	if (internalCommand === "enable-hints") {
+		await updateHintsToggle("global", true);
 	}
 
 	if (internalCommand === "toggle-keyboard-clicking") {

--- a/src/background/commands/dispatchCommand.ts
+++ b/src/background/commands/dispatchCommand.ts
@@ -39,12 +39,6 @@ const backgroundCommands = new Set([
 export async function dispatchCommand(
 	command: RangoAction
 ): Promise<ResponseToTalon> {
-	try {
-		await sendRequestToContent({ type: "allowToastNotification" });
-	} catch {
-		// No content script. We do nothing.
-	}
-
 	const result = (await (backgroundCommands.has(command.type)
 		? runBackgroundCommand(command)
 		: sendRequestToContent(command))) as string | TalonAction[] | undefined;

--- a/src/mv2-safari/manifest.json
+++ b/src/mv2-safari/manifest.json
@@ -63,13 +63,6 @@
 			},
 			"description": "Toggle hints"
 		},
-		"disable-hints": {
-			"suggested_key": {
-				"default": "Ctrl+Shift+4",
-				"mac": "MacCtrl+Shift+4"
-			},
-			"description": "Disable hints"
-		},
 		"toggle-keyboard-clicking": {
 			"suggested_key": {
 				"default": "Ctrl+Shift+5",

--- a/src/mv2/manifest.json
+++ b/src/mv2/manifest.json
@@ -69,6 +69,13 @@
 			},
 			"description": "Disable hints"
 		},
+		"enable-hints": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+6",
+				"mac": "MacCtrl+Shift+6"
+			},
+			"description": "Enable hints"
+		},
 		"toggle-keyboard-clicking": {
 			"suggested_key": {
 				"default": "Ctrl+Shift+5",

--- a/src/mv3/manifest.json
+++ b/src/mv3/manifest.json
@@ -65,6 +65,9 @@
 			},
 			"description": "Disable hints"
 		},
+		"enable-hints": {
+			"description": "Enable hints"
+		},
 		"toggle-keyboard-clicking": {
 			"description": "Toggle keyboard clicking"
 		}


### PR DESCRIPTION
Add command to enable hints with a shortcut in Chrome and Safari.

Remove command to disable hints in Safari with a shortcut as it only allows four shortcuts.