### PR TITLE
Improve the behavior of commands that place the cursor within or manipulate input text

### DIFF
--- a/e2e/noContentScript.test.ts
+++ b/e2e/noContentScript.test.ts
@@ -33,7 +33,7 @@ describe("Background commands", () => {
 
 		expect(action).toBeDefined();
 
-		const textToCopy = action.textToCopy;
+		const textToCopy = "textToCopy" in action ? action.textToCopy : undefined;
 
 		expect(textToCopy).toBeDefined();
 		expect(textToCopy).toBe("chrome://new-tab-page/");

--- a/src/background/utils/constructTalonResponse.ts
+++ b/src/background/utils/constructTalonResponse.ts
@@ -4,8 +4,6 @@ import {
 	TalonActionLegacy,
 } from "../../typings/RequestFromTalon";
 
-type PropType<TObject, TProp extends keyof TObject> = TObject[TProp];
-
 export function constructTalonResponse(
 	actions: TalonAction[]
 ): ResponseToTalon {
@@ -28,12 +26,12 @@ export function constructTalonResponse(
 
 	if (mainAction) {
 		legacyAction = {
-			type:
-				mainAction.previousName ??
-				(mainAction.name as PropType<TalonActionLegacy, "type">),
-			key: mainAction.key,
-			textToCopy: mainAction.textToCopy,
+			type: ("previousName" in mainAction
+				? mainAction.previousName
+				: mainAction.name) as TalonActionLegacy["type"],
 		};
+		if ("key" in mainAction) legacyAction.key = mainAction.key;
+		if ("textToCopy" in mainAction) legacyAction.key = mainAction.textToCopy;
 	} else {
 		legacyAction = { type: "noAction" };
 	}

--- a/src/background/utils/shouldTryToFocusDocument.ts
+++ b/src/background/utils/shouldTryToFocusDocument.ts
@@ -1,0 +1,25 @@
+import { promiseWrap } from "../../lib/promiseWrap";
+import { sendRequestToContent } from "../messaging/sendRequestToContent";
+
+let triedToFocusDocument = false;
+
+export async function shouldTryToFocusDocument(): Promise<boolean> {
+	// This only works in Firefox, and I'm not sure if always
+	await sendRequestToContent({ type: "tryToFocusPage" });
+
+	const [focusedDocument] = await promiseWrap(
+		sendRequestToContent({
+			type: "checkIfDocumentHasFocus",
+		})
+	);
+
+	if (!focusedDocument && !triedToFocusDocument) {
+		triedToFocusDocument = true;
+		setTimeout(() => {
+			triedToFocusDocument = false;
+		}, 3000);
+		return true;
+	}
+
+	return false;
+}

--- a/src/content/actions/focus.ts
+++ b/src/content/actions/focus.ts
@@ -1,6 +1,7 @@
 import { TalonAction } from "../../typings/RequestFromTalon";
 import { notify } from "../notify/notify";
 import { dispatchKeyDown, dispatchKeyUp } from "../utils/dispatchEvents";
+import { editableElementSelector } from "../utils/domUtils";
 import { Wrapper } from "../wrappers/Wrapper";
 import { getWrapperForElement } from "../wrappers/wrappers";
 
@@ -34,9 +35,7 @@ export function focus(wrappers: Wrapper[]): TalonAction[] | undefined {
 }
 
 export async function focusFirstInput() {
-	const firstInput = document.querySelector(
-		"input:not(:is([type='button'], [type='checkbox'], [type='color'], [type='file'], [type='hidden'], [type='image'], [type='radio'], [type='reset'], [type='submit'])), textarea, [contenteditable=''], [contenteditable='true']"
-	);
+	const firstInput = document.querySelector(editableElementSelector);
 
 	if (!firstInput) {
 		await notify("No input found", { type: "error" });

--- a/src/content/actions/insertToField.ts
+++ b/src/content/actions/insertToField.ts
@@ -2,7 +2,7 @@ import { ElementWrapper } from "../../typings/ElementWrapper";
 import { isFieldWithValue } from "../../typings/TypingUtils";
 import { setSelectionAfter } from "./setSelection";
 
-export function insertToField(wrappers: ElementWrapper[], text: string) {
+export async function insertToField(wrappers: ElementWrapper[], text: string) {
 	for (const wrapper of wrappers) {
 		wrapper.hint?.flash();
 		if (isFieldWithValue(wrapper.element)) {
@@ -13,7 +13,7 @@ export function insertToField(wrappers: ElementWrapper[], text: string) {
 	}
 
 	const lastWrapper = wrappers[wrappers.length - 1]!;
-	setSelectionAfter(lastWrapper);
+	await setSelectionAfter(lastWrapper);
 	if (lastWrapper.element instanceof HTMLElement) {
 		lastWrapper.element.focus();
 	}

--- a/src/content/actions/runRangoActionWithTarget.ts
+++ b/src/content/actions/runRangoActionWithTarget.ts
@@ -98,6 +98,8 @@ export async function runRangoActionWithTarget(
 		case "copyElementTextContent":
 			return copyElementTextContentToClipboard(wrappers);
 
+		// This is not used anymore. I leave it here for now for backwards
+		// compatibility - 2023-06-02
 		case "insertToField":
 			await insertToField(wrappers, request.arg);
 			break;
@@ -114,6 +116,8 @@ export async function runRangoActionWithTarget(
 			await setSelectionAfter(wrapper);
 			break;
 
+		// This is not used anymore. I leave it here for now for backwards
+		// compatibility - 2023-06-02
 		case "focusAndDeleteContents":
 			return focusAndDeleteContents(wrapper);
 

--- a/src/content/actions/runRangoActionWithTarget.ts
+++ b/src/content/actions/runRangoActionWithTarget.ts
@@ -99,7 +99,7 @@ export async function runRangoActionWithTarget(
 			return copyElementTextContentToClipboard(wrappers);
 
 		case "insertToField":
-			insertToField(wrappers, request.arg);
+			await insertToField(wrappers, request.arg);
 			break;
 
 		case "setSelectionBefore":

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -87,6 +87,10 @@ browser.runtime.onMessage.addListener(
 					allowToastNotification();
 					break;
 
+				case "tryToFocusPage":
+					window.focus();
+					break;
+
 				default: {
 					const result = await runRangoActionWithoutTarget(request);
 					return result;

--- a/src/content/utils/domUtils.ts
+++ b/src/content/utils/domUtils.ts
@@ -1,0 +1,8 @@
+export const editableElementSelector =
+	"input:not(:is([type='button'], [type='checkbox'], [type='color'], [type='file'], [type='hidden'], [type='image'], [type='radio'], [type='reset'], [type='submit'])), textarea, [contenteditable=''], [contenteditable='true']";
+
+export function elementIsEditable(element: Element | null) {
+	if (!element) return false;
+
+	return element.matches(editableElementSelector);
+}

--- a/src/content/utils/focusesOnclick.ts
+++ b/src/content/utils/focusesOnclick.ts
@@ -12,7 +12,8 @@ export function focusesOnclick(element: Element): boolean {
 		return true;
 	}
 
-	if (element.getAttribute("contenteditable") === "true") {
+	const contentEditable = element.getAttribute("contenteditable");
+	if (contentEditable === "" || contentEditable === "true") {
 		return true;
 	}
 

--- a/src/content/utils/nodeUtils.ts
+++ b/src/content/utils/nodeUtils.ts
@@ -55,3 +55,27 @@ export function getFirstTextNodeDescendant(element: Node): Text | undefined {
 
 	return undefined;
 }
+
+export function findLastTextNode(element: Node): Text | undefined {
+	if (element instanceof Text) return element;
+
+	for (let i = element.childNodes.length - 1; i >= 0; i--) {
+		const lastTextNode = findLastTextNode(element.childNodes[i]!);
+
+		if (lastTextNode) return lastTextNode;
+	}
+
+	return undefined;
+}
+
+export function findFirstTextNode(element: Node): Text | undefined {
+	if (element instanceof Text) return element;
+
+	for (const child of element.childNodes) {
+		const firstTextNode = findFirstTextNode(child);
+
+		if (firstTextNode) return firstTextNode;
+	}
+
+	return undefined;
+}

--- a/src/content/utils/tryToFocusOnEditable.ts
+++ b/src/content/utils/tryToFocusOnEditable.ts
@@ -1,0 +1,52 @@
+import { sleep } from "../../lib/utils";
+import { ElementWrapper } from "../../typings/ElementWrapper";
+import { notify } from "../notify/notify";
+import { elementIsEditable } from "./domUtils";
+
+async function waitActiveElementIsEditable(): Promise<boolean> {
+	return new Promise((resolve) => {
+		let timedOut = false;
+
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			resolve(false);
+		}, 500);
+
+		const poll = () => {
+			if (!elementIsEditable(document.activeElement) && !timedOut) {
+				setTimeout(() => {
+					poll();
+				}, 20);
+			} else {
+				clearTimeout(timeout);
+				resolve(true);
+			}
+		};
+
+		poll();
+	});
+}
+
+/**
+ * Try to bring the focus on an editable element. We first click it (as long as
+ * the element is not a link) so that the caret is placed within it or an
+ * editable element might appear.
+ */
+export async function tryToFocusOnEditable(wrapper: ElementWrapper) {
+	if (wrapper.element instanceof HTMLAnchorElement) {
+		await notify(
+			`The element with hint "${wrapper.hint!.string!}" is not editable`,
+			{ type: "error" }
+		);
+		return false;
+	}
+
+	wrapper.click();
+
+	// We need to add a sleep here so that the focus has had time to move to the
+	// clicked element. If we call waitActiveElementIsEditable too early we might
+	// get the previously focused element.
+	await sleep(50);
+
+	return waitActiveElementIsEditable();
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,3 +6,11 @@ export function hasMatchingKeys(object1: object, object2: object): boolean {
 
 	return keys1.some((key) => keys2.includes(key));
 }
+
+export async function sleep(ms: number) {
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			resolve(true);
+		}, ms);
+	});
+}

--- a/src/typings/RangoAction.ts
+++ b/src/typings/RangoAction.ts
@@ -35,7 +35,8 @@ interface RangoActionWithoutTargetWithoutArg {
 		| "includeOrExcludeLessSelectors"
 		| "confirmSelectorsCustomization"
 		| "resetCustomSelectors"
-		| "openSettingsPage";
+		| "openSettingsPage"
+		| "requestTimedOut";
 }
 
 export interface RangoActionUpdateToggles {

--- a/src/typings/RangoAction.ts
+++ b/src/typings/RangoAction.ts
@@ -91,6 +91,7 @@ interface RangoActionWithTargets {
 	type:
 		| "openInBackgroundTab"
 		| "clickElement"
+		| "tryToFocusElementAndCheckIsEditable"
 		| "focusElement"
 		| "directClickElement"
 		| "openInNewTab"

--- a/src/typings/RequestFromBackground.ts
+++ b/src/typings/RequestFromBackground.ts
@@ -31,7 +31,8 @@ interface SimpleContentRequest {
 	type:
 		| "restoreKeyboardReachableHints"
 		| "checkIfDocumentHasFocus"
-		| "onCompleted";
+		| "onCompleted"
+		| "tryToFocusPage";
 }
 
 export type RequestFromBackground = { frameId?: number } & (

--- a/src/typings/RequestFromTalon.ts
+++ b/src/typings/RequestFromTalon.ts
@@ -6,21 +6,54 @@ export interface RequestFromTalon {
 	action: RangoAction;
 }
 
-export interface TalonAction {
-	name:
-		| "copyToClipboard"
-		| "typeTargetCharacters"
-		| "key"
-		| "editDelete"
-		| "sleep"
-		| "focusPage";
-	main?: true;
-	previousName?: "noHintFound" | "editDeleteAfterDelay";
-	textToCopy?: string;
-	text?: string;
-	key?: string;
+interface TalonActionCopyToClipboard {
+	name: "copyToClipboard";
+	textToCopy: string;
+}
+
+interface TalonActionTypeTargetCharacters {
+	name: "typeTargetCharacters";
+	previousName?: "noHintFound";
+}
+
+interface TalonActionKey {
+	name: "key";
+	key: string;
+}
+
+interface TalonActionEditDelete {
+	name: "editDelete";
+	previousName?: "editDeleteAfterDelay";
+}
+
+interface TalonActionSleep {
+	name: "sleep";
 	ms?: number;
 }
+
+interface TalonActionFocusPage {
+	name: "focusPage";
+}
+
+interface TalonActionFocusPageAndResend {
+	name: "focusPageAndResend";
+}
+
+interface TalonActionResponseValue {
+	name: "responseValue";
+	value: any;
+}
+
+export type TalonAction = { main?: true } & (
+	| TalonActionCopyToClipboard
+	| TalonActionTypeTargetCharacters
+	| TalonActionKey
+	| TalonActionEditDelete
+	| TalonActionSleep
+	| TalonActionFocusPage
+	| TalonActionFocusPageAndResend
+	| TalonActionResponseValue
+);
 
 export interface ResponseToTalon {
 	type: "response";


### PR DESCRIPTION
- Fix elements with contenteditable="" not considered to focus on click.
- Make `change` work even if the page is not focused.
- Make these commands work even when you previously have to click some button.
- Improve types of TalonAction.
- Add check to avoid writing the response to the clipboard if talon is not waiting for one