### PR TITLE
Fix performance issue when calculating if element has significant siblings

### DIFF
--- a/src/content/hints/selectors.ts
+++ b/src/content/hints/selectors.ts
@@ -2,7 +2,7 @@ import { retrieve, store } from "../../common/storage";
 
 const defaultSelector =
 	// Elements
-	"button, a, input, summary, textarea, select, option, label, " +
+	"button, a, input, summary, textarea, select, label, " +
 	// Roles
 	"[role='button'], [role='link'], [role='treeitem'], [role='tab'], [role='option'], " +
 	"[role='radio'], [role='checkbox'], [role='menuitem'], [role='menuitemradio'], [role='menuitemcheckbox'], " +


### PR DESCRIPTION
The issue appeared if the parent of the target element had many children. Caused the extension to stall in a page with a select with ~2000 options.