### PR TITLE
Fix reclaimHintsFromOtherFrames always returning undefined

### DIFF
--- a/src/background/hints/hintsAllocator.ts
+++ b/src/background/hints/hintsAllocator.ts
@@ -91,7 +91,7 @@ export async function reclaimHintsFromOtherFrames(
 	frameId: number,
 	amount: number
 ) {
-	await withStack(tabId, async (stack) => {
+	return withStack(tabId, async (stack) => {
 		const frames = await browser.webNavigation.getAllFrames({ tabId });
 		const otherFramesIds = frames
 			.map((frame) => frame.frameId)


### PR DESCRIPTION
This was causing some hints to not display, especially when using `hint extra`.