### PR TITLE
Remove alt text from Rango logo to hide from assistive technologies

### DIFF
--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -14,7 +14,7 @@ export function App({ hasSeenSettingsPage }: AppProps) {
 	return (
 		<div className="App">
 			<h1>
-				<img className="rango-logo" src={iconSvgUrl.href} alt="Rango logo" />{" "}
+				<img className="rango-logo" src={iconSvgUrl.href} alt="" />{" "}
 				Rango Settings
 			</h1>
 			{!hasSeenSettingsPage && (

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -14,7 +14,7 @@ export function App({ hasSeenSettingsPage }: AppProps) {
 	return (
 		<div className="App">
 			<h1>
-				<img className="rango-logo" src={iconSvgUrl.href} alt="" />{" "}
+				<img className="rango-logo" src={iconSvgUrl.href} alt="" />
 				Rango Settings
 			</h1>
 			{!hasSeenSettingsPage && (


### PR DESCRIPTION
Rango's logo on the setting page has the alt-text "Rango logo" but the image is decorative in nature and doesn't provide any information so it should be hidden from assistive technologies: https://www.w3.org/WAI/tutorials/images/decorative/.