### PR TITLE
Remove custom styled controls detection

### DIFF
--- a/src/content/utils/isVisible.ts
+++ b/src/content/utils/isVisible.ts
@@ -5,16 +5,6 @@ export function isVisible(element: Element): boolean {
 	const { width, height } = getBoundingClientRect(element);
 
 	if (visibility === "hidden" || width < 5 || height < 5 || opacity === "0") {
-		// This handles custom checkboxes or toggle buttons where the input/button
-		// element is hidden and replaced with an stylized sibling.
-		if (
-			element.matches("input[type='checkbox'], button") &&
-			element.parentElement &&
-			isVisible(element.parentElement)
-		) {
-			return true;
-		}
-
 		return false;
 	}
 


### PR DESCRIPTION
This removes the code for trying to detect if an element that is not visible is in reality a custom control (checkbox, toggle,...). It was causing false positives and not hiding hints when it should.