### PR TITLE
Fix crash when running out of tab markers

### DIFF
--- a/src/background/misc/tabMarkers.ts
+++ b/src/background/misc/tabMarkers.ts
@@ -23,9 +23,7 @@ export async function getTabMarker(tabId: number) {
 	return withTabMarkers(({ free, tabIdsToMarkers, markersToTabIds }) => {
 		const marker = tabIdsToMarkers.get(tabId) ?? free.pop();
 
-		if (!marker) {
-			throw new Error("No more tab markers available");
-		}
+		if (!marker) return "";
 
 		tabIdsToMarkers.set(tabId, marker);
 		markersToTabIds.set(marker, tabId);
@@ -47,6 +45,8 @@ export async function getTabIdForMarker(marker: string) {
 
 async function releaseMarker(tabId: number) {
 	const marker = await getTabMarker(tabId);
+	if (!marker) return;
+
 	await withTabMarkers(({ free, tabIdsToMarkers, markersToTabIds }) => {
 		tabIdsToMarkers.delete(tabId);
 		markersToTabIds.delete(marker);

--- a/src/content/utils/decorateTitle.ts
+++ b/src/content/utils/decorateTitle.ts
@@ -19,6 +19,8 @@ async function getTitlePrefix() {
 		type: "getTabMarker",
 	})) as string;
 
+	if (!tabMarker) return "";
+
 	const marker = uppercaseTabMarkers ? tabMarker.toUpperCase() : tabMarker;
 
 	return `${marker} | `;


### PR DESCRIPTION
This would only happen if the user has more than ~700 tabs open. With this fix tabs beyond that simply wouldn't get a tab marker.