### PR TITLE
Improve-scroll-positions

### DIFF
--- a/src/content/actions/customScrollPositions.ts
+++ b/src/content/actions/customScrollPositions.ts
@@ -14,11 +14,15 @@ export async function storeScrollPosition(name: string) {
 
 	const scrollPositions = await retrieve("customScrollPositions");
 	const scrollPositionsForCurrentPage =
-		scrollPositions.get(window.location.href) ?? new Map<string, number>();
+		scrollPositions.get(window.location.origin + window.location.pathname) ??
+		new Map<string, number>();
 
 	scrollPositionsForCurrentPage.set(name, scrollTop);
 
-	scrollPositions.set(window.location.href, scrollPositionsForCurrentPage);
+	scrollPositions.set(
+		window.location.origin + window.location.pathname,
+		scrollPositionsForCurrentPage
+	);
 	await store("customScrollPositions", scrollPositions);
 
 	await notify(`Scroll position "${name}" saved`, { type: "success" });
@@ -29,7 +33,8 @@ export async function scrollToPosition(name: string) {
 
 	const scrollPositions = await retrieve("customScrollPositions");
 	const scrollPositionsForCurrentPage =
-		scrollPositions.get(window.location.href) ?? new Map<string, number>();
+		scrollPositions.get(window.location.origin + window.location.pathname) ??
+		new Map<string, number>();
 
 	const position = scrollPositionsForCurrentPage.get(name);
 

--- a/src/content/actions/customScrollPositions.ts
+++ b/src/content/actions/customScrollPositions.ts
@@ -1,3 +1,4 @@
+import Fuse from "fuse.js";
 import { retrieve, store } from "../../common/storage";
 import { notify } from "../notify/notify";
 import { getMainScrollable, getScrollBehavior } from "./scroll";
@@ -36,10 +37,19 @@ export async function scrollToPosition(name: string) {
 		scrollPositions.get(window.location.origin + window.location.pathname) ??
 		new Map<string, number>();
 
-	const position = scrollPositionsForCurrentPage.get(name);
+	const scrollPositionsArray = [...scrollPositionsForCurrentPage].map(
+		([name, number]) => ({ name, number })
+	);
+
+	const fuse = new Fuse(scrollPositionsArray, {
+		keys: ["name"],
+	});
+
+	const results = fuse.search(name);
+	const position = results[0]?.item.number;
 
 	if (!position) {
-		await notify(`No scroll position saved for "${name}"`, { type: "error" });
+		await notify(`No scroll position matching "${name}"`, { type: "error" });
 		return;
 	}
 


### PR DESCRIPTION
- Only include the origin plus the path when saving scroll positions. This makes it so that if the user is in a page with a hash or a query in the URL the saved position still works.

- Use fuzzy search for retrieving saved scroll positions.