### PR TITLE
Fix hints not being shown with new color spaces in CSS Colors v4

### DIFF
--- a/src/content/hints/HintClass.ts
+++ b/src/content/hints/HintClass.ts
@@ -404,9 +404,12 @@ export class HintClass implements Hint {
 			} else {
 				const elementToGetColorFrom =
 					this.firstTextNodeDescendant?.parentElement;
-				const colorString = window.getComputedStyle(
+				let colorString = window.getComputedStyle(
 					elementToGetColorFrom ?? this.target
 				).color;
+				colorString = colorString.startsWith("rgb")
+					? colorString
+					: "rgb(0, 0, 0)";
 				color = rgbaToRgb(new Color(colorString || "black"), backgroundColor);
 
 				if (!elementToGetColorFrom) {

--- a/src/content/utils/getEffectiveBackgroundColor.ts
+++ b/src/content/utils/getEffectiveBackgroundColor.ts
@@ -44,7 +44,11 @@ export function getEffectiveBackgroundColor(element: Element) {
 	let current: Element | null = element;
 
 	while (current) {
-		const { backgroundColor } = window.getComputedStyle(current);
+		let { backgroundColor } = window.getComputedStyle(current);
+
+		if (!backgroundColor.startsWith("rgb")) {
+			backgroundColor = "rgb(255, 255, 255)";
+		}
 
 		if (backgroundColor && backgroundColor !== "rgba(0, 0, 0, 0)") {
 			if (isRgb(backgroundColor)) {


### PR DESCRIPTION
This pull request fixes the error when we encounter a color that it's not in RGB space, like lch, lab, ... It still doesn't handle colors appropriately but it will default to white background and black text.