### PR TITLE
Update dependencies jest-puppeteer, xo and eslint plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
         with:
-          node-version: 18
+          node-version: 20
       - run: npm install
       - uses: david-tejada/puppeteer-headful@master
         with:

--- a/.xo-config.json
+++ b/.xo-config.json
@@ -1,0 +1,113 @@
+{
+	"extends": ["xo-react", "plugin:react/jsx-runtime"],
+	"parserOptions": {
+		"project": "./tsconfig.xo.json"
+	},
+	"envs": ["browser"],
+	"prettier": "true",
+	"globals": {
+		"page": true,
+		"browser": true,
+		"context": true,
+		"jestPuppeteer": true
+	},
+	"rules": {
+		"@typescript-eslint/switch-exhaustiveness-check": "off",
+		"no-unused-vars": [
+			"error",
+			{
+				"varsIgnorePattern": "browser"
+			}
+		],
+		"unicorn/prefer-top-level-await": "off",
+		"n/file-extension-in-import": "off",
+		"import/extensions": [
+			2,
+			"never",
+			{
+				"png": "always",
+				"html": "always"
+			}
+		],
+		"unicorn/filename-case": [
+			"error",
+			{
+				"cases": {
+					"camelCase": true,
+					"pascalCase": true
+				}
+			}
+		],
+		"node/prefer-global/process": "off",
+		"complexity": "off",
+		"no-use-extend-native/no-use-extend-native": "off",
+		"unicorn/no-array-callback-reference": "off",
+		"unicorn/prefer-node-protocol": "off",
+		"@typescript-eslint/ban-types": "off",
+		"no-redeclare": "off",
+		"@typescript-eslint/no-redeclare": "off",
+		"unicorn/prevent-abbreviations": [
+			"error",
+			{
+				"extendDefaultAllowList": true,
+				"allowList": {
+					"arg": true,
+					"i": true
+				},
+				"replacements": {
+					"props": false
+				}
+			}
+		]
+	},
+	"overrides": [
+		{
+			"files": ["src/background/**"],
+			"rules": {
+				"no-restricted-imports": [
+					"error",
+					{
+						"patterns": [
+							{
+								"group": ["**/content/**"],
+								"message": "Modules within /src/background can't import from /src/content"
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			"files": ["src/content/**"],
+			"rules": {
+				"no-restricted-imports": [
+					"error",
+					{
+						"patterns": [
+							{
+								"group": ["**/background/**"],
+								"message": "Modules within /src/content can't import from /src/background"
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			"files": ["src/common/**"],
+			"rules": {
+				"no-restricted-imports": [
+					"error",
+					{
+						"patterns": [
+							{
+								"group": ["**/background/**", "**/content/**"],
+								"message": "Modules within /src/content can't import from /src/background or /src/content"
+							}
+						]
+					}
+				]
+			}
+		}
+	]
+}

--- a/e2e/customHints.test.ts
+++ b/e2e/customHints.test.ts
@@ -1,4 +1,4 @@
-import { ElementHandle, Frame } from "puppeteer";
+import { type ElementHandle, type Frame } from "puppeteer";
 import { getHintForElement } from "./utils/getHintForElement";
 import {
 	rangoCommandWithTarget,
@@ -20,7 +20,7 @@ describe("Main frame", () => {
 	});
 
 	test("Extra hints are saved", async () => {
-		const hintable = await page.$("#custom-button")!;
+		const hintable = await page.$("#custom-button");
 		const hint = await hintable!.evaluate(getHintForElement);
 
 		await rangoCommandWithTarget("includeExtraSelectors", [hint]);
@@ -68,7 +68,7 @@ describe("iFrame", () => {
 	});
 
 	test("Extra hints are saved", async () => {
-		const hintable = await frame.$("#custom-button")!;
+		const hintable = await frame.$("#custom-button");
 		const hint = await hintable!.evaluate(getHintForElement);
 
 		await rangoCommandWithTarget("includeExtraSelectors", [hint]);
@@ -114,7 +114,7 @@ describe("Staging", () => {
 	});
 
 	test("Hints marked are removed after refreshing hints", async () => {
-		const hintable = await page.$("#custom-button")!;
+		const hintable = await page.$("#custom-button");
 		const hint = await hintable!.evaluate(getHintForElement);
 
 		await rangoCommandWithTarget("includeExtraSelectors", [hint]);
@@ -132,7 +132,7 @@ describe("Staging", () => {
 	});
 
 	test("Hints marked are removed after custom hints reset", async () => {
-		const hintable = await page.$("#custom-button")!;
+		const hintable = await page.$("#custom-button");
 		const hint = await hintable!.evaluate(getHintForElement);
 
 		await rangoCommandWithTarget("includeExtraSelectors", [hint]);

--- a/e2e/keyboardClicking.test.ts
+++ b/e2e/keyboardClicking.test.ts
@@ -1,5 +1,5 @@
 import { keyTap } from "@hurdlegroup/robotjs";
-import { Frame, Page } from "puppeteer";
+import { type Frame, type Page } from "puppeteer";
 import { rangoCommandWithoutTarget } from "./utils/rangoCommands";
 import { sleep } from "./utils/testHelpers";
 

--- a/e2e/noContentScript.test.ts
+++ b/e2e/noContentScript.test.ts
@@ -1,5 +1,5 @@
 import clipboard from "clipboardy";
-import { ResponseToTalon } from "../src/typings/RequestFromTalon";
+import { type ResponseToTalon } from "../src/typings/RequestFromTalon";
 import {
 	rangoCommandWithTarget,
 	rangoCommandWithoutTarget,

--- a/e2e/scroll.test.ts
+++ b/e2e/scroll.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-nested-callbacks */
-import { ElementHandle } from "puppeteer";
+import { type ElementHandle } from "puppeteer";
 import {
 	rangoCommandWithoutTarget,
 	rangoCommandWithTarget,
@@ -56,7 +56,7 @@ async function getActionableHint(containerSelector: string, top = true) {
 		if (visible) $$visible.push($node);
 	}
 
-	const $target = top ? $$visible[0] : $$visible[$$visible.length - 1];
+	const $target = top ? $$visible[0] : $$visible.at(-1);
 
 	return $target!.evaluate(getHintForElement);
 }

--- a/e2e/utils/testHelpers.ts
+++ b/e2e/utils/testHelpers.ts
@@ -1,5 +1,5 @@
 export async function sleep(ms: number) {
-	return new Promise((r) => {
-		setTimeout(r, ms);
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
 	});
 }

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -9,7 +9,7 @@ module.exports = {
 		product: "chrome",
 		executablePath: process.env.PUPPETEER_EXEC_PATH,
 		args: [
-			"no-sandbox",
+			"--no-sandbox",
 			`--disable-extensions-except=${EXTENSION_PATH}`,
 			`--load-extension=${EXTENSION_PATH}`,
 		],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5292,9 +5292,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001519",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
-			"integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
+			"version": "1.0.30001662",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz",
+			"integrity": "sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==",
 			"dev": true,
 			"funding": [
 				{
@@ -23137,9 +23137,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001519",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
-			"integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
+			"version": "1.0.30001662",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz",
+			"integrity": "sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==",
 			"dev": true
 		},
 		"caseless": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,8 @@
 				"eslint-config-xo": "^0.40.0",
 				"eslint-config-xo-react": "^0.27.0",
 				"eslint-config-xo-typescript": "^0.50.0",
-				"eslint-plugin-react": "^7.32.2",
-				"eslint-plugin-react-hooks": "^4.6.0",
+				"eslint-plugin-react": "^7.36.1",
+				"eslint-plugin-react-hooks": "^4.6.2",
 				"jest": "^29.4.3",
 				"jest-environment-jsdom": "^29.4.3",
 				"jest-puppeteer": "^10.1.1",
@@ -66,7 +66,7 @@
 				"ts-unused-exports": "^8.0.5",
 				"typescript": "^5.6.2",
 				"web-ext": "^7.4.0",
-				"xo": "^0.48.0"
+				"xo": "^0.59.3"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -778,24 +778,24 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
-			"integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+			"integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+			"integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
-				"globals": "^13.19.0",
+				"espree": "^10.0.1",
+				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -803,10 +803,51 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/espree": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+			"integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.12.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/globals": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@eslint/js": {
@@ -1615,24 +1656,24 @@
 			}
 		},
 		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+			"integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
 			}
 		},
 		"node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/trace-mapping": "^0.3.24"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -3036,6 +3077,18 @@
 				"@parcel/core": "^2.8.3"
 			}
 		},
+		"node_modules/@pkgr/core": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+			"integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts"
+			}
+		},
 		"node_modules/@pnpm/network.ca-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
@@ -3069,6 +3122,18 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/popperjs"
 			}
+		},
+		"node_modules/@rtsao/scc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+			"integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+			"dev": true
+		},
+		"node_modules/@sec-ant/readable-stream": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+			"dev": true
 		},
 		"node_modules/@sideway/address": {
 			"version": "4.1.5",
@@ -3107,6 +3172,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+			"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@sindresorhus/tsconfig": {
@@ -3289,30 +3366,19 @@
 			"dev": true
 		},
 		"node_modules/@types/eslint": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
-			"integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+			"version": "8.56.12",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+			"integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
 			}
 		},
-		"node_modules/@types/eslint-scope": {
-			"version": "3.7.4",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@types/eslint": "*",
-				"@types/estree": "*"
-			}
-		},
 		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true
 		},
 		"node_modules/@types/filesystem": {
@@ -4025,74 +4091,80 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"dev": true
+		},
 		"node_modules/@webassemblyjs/ast": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
+			"integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@webassemblyjs/helper-numbers": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+				"@webassemblyjs/helper-numbers": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+			"integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+			"integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
+			"integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+			"integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@webassemblyjs/floating-point-hex-parser": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+			"integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
+			"integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1"
+				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/helper-buffer": "1.12.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.12.1"
 			}
 		},
 		"node_modules/@webassemblyjs/ieee754": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+			"integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -4100,9 +4172,9 @@
 			}
 		},
 		"node_modules/@webassemblyjs/leb128": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+			"integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -4110,79 +4182,79 @@
 			}
 		},
 		"node_modules/@webassemblyjs/utf8": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+			"integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
+			"integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/helper-wasm-section": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-opt": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
-				"@webassemblyjs/wast-printer": "1.11.1"
+				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/helper-buffer": "1.12.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/helper-wasm-section": "1.12.1",
+				"@webassemblyjs/wasm-gen": "1.12.1",
+				"@webassemblyjs/wasm-opt": "1.12.1",
+				"@webassemblyjs/wasm-parser": "1.12.1",
+				"@webassemblyjs/wast-printer": "1.12.1"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-gen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
+			"integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-opt": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
+			"integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1"
+				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/helper-buffer": "1.12.1",
+				"@webassemblyjs/wasm-gen": "1.12.1",
+				"@webassemblyjs/wasm-parser": "1.12.1"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
+			"integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/helper-api-error": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/wast-printer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
+			"integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/ast": "1.12.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
@@ -4225,9 +4297,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -4246,10 +4318,10 @@
 				"acorn-walk": "^8.0.2"
 			}
 		},
-		"node_modules/acorn-import-assertions": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+		"node_modules/acorn-import-attributes": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
 			"dev": true,
 			"peer": true,
 			"peerDependencies": {
@@ -4617,6 +4689,22 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"node_modules/array-buffer-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"is-array-buffer": "^3.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/array-differ": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
@@ -4629,22 +4717,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/array-find": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
-			"integrity": "sha512-kO/vVCacW9mnpn3WPWbTVlEnOabK2L7LWi2HViURtCM46y1zb6I8UMjx4LgbiqadTgHnLInUronwn3ampNTJtQ==",
-			"dev": true
-		},
 		"node_modules/array-includes": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
-			"integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+			"integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"get-intrinsic": "^1.1.3",
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
 				"is-string": "^1.0.7"
 			},
 			"engines": {
@@ -4663,15 +4746,55 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/array.prototype.findlast": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+			"integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.findlastindex": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
+			"integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/array.prototype.flat": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+			"integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"es-shim-unscopables": "^1.0.0"
 			},
 			"engines": {
@@ -4682,14 +4805,14 @@
 			}
 		},
 		"node_modules/array.prototype.flatmap": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
-			"integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+			"integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"es-shim-unscopables": "^1.0.0"
 			},
 			"engines": {
@@ -4700,16 +4823,41 @@
 			}
 		},
 		"node_modules/array.prototype.tosorted": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
-			"integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+			"integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"es-shim-unscopables": "^1.0.0",
-				"get-intrinsic": "^1.1.3"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3",
+				"es-errors": "^1.3.0",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/arraybuffer.prototype.slice": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+			"integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.1",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.22.3",
+				"es-errors": "^1.2.1",
+				"get-intrinsic": "^1.2.3",
+				"is-array-buffer": "^3.0.4",
+				"is-shared-array-buffer": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/arrify": {
@@ -4786,10 +4934,13 @@
 			}
 		},
 		"node_modules/available-typed-arrays": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
 			"dev": true,
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -5042,21 +5193,21 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"version": "4.23.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+			"integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
 			"dev": true,
 			"funding": [
 				{
@@ -5066,13 +5217,17 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001400",
-				"electron-to-chromium": "^1.4.251",
-				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.9"
+				"caniuse-lite": "^1.0.30001646",
+				"electron-to-chromium": "^1.5.4",
+				"node-releases": "^2.0.18",
+				"update-browserslist-db": "^1.1.0"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -5159,6 +5314,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/bunyan": {
 			"version": "1.8.15",
 			"resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
@@ -5214,13 +5384,19 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
 			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -5851,6 +6027,12 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/common-path-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+			"integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+			"dev": true
+		},
 		"node_modules/common-tags": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -5859,12 +6041,6 @@
 			"engines": {
 				"node": ">=4.0.0"
 			}
-		},
-		"node_modules/commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-			"dev": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -5988,6 +6164,19 @@
 			"integrity": "sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==",
 			"dev": true,
 			"hasInstallScript": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
+			}
+		},
+		"node_modules/core-js-compat": {
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
+			"integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.23.3"
+			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
@@ -6245,6 +6434,57 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/data-view-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+			"integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/data-view-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+			"integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/data-view-byte-offset": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+			"integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/debounce": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -6374,6 +6614,34 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/default-browser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+			"dev": true,
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -6404,6 +6672,23 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/define-lazy-prop": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -6414,11 +6699,12 @@
 			}
 		},
 		"node_modules/define-properties": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
 			"dev": true,
 			"dependencies": {
+				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			},
@@ -6655,9 +6941,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.284",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+			"version": "1.5.26",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.26.tgz",
+			"integrity": "sha512-Z+OMe9M/V6Ep9n/52+b7lkvYEps26z4Yz3vjWL1V61W0q+VLF1pOHhMY17sa4roz4AWmULSI8E6SAojZA5L0YQ==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -6736,6 +7022,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -6746,44 +7041,57 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.21.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-			"integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+			"version": "1.23.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+			"integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
 			"dev": true,
 			"dependencies": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"es-set-tostringtag": "^2.0.1",
+				"array-buffer-byte-length": "^1.0.1",
+				"arraybuffer.prototype.slice": "^1.0.3",
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"data-view-buffer": "^1.0.1",
+				"data-view-byte-length": "^1.0.1",
+				"data-view-byte-offset": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-set-tostringtag": "^2.0.3",
 				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
-				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.3",
-				"get-symbol-description": "^1.0.0",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.4",
+				"get-symbol-description": "^1.0.2",
 				"globalthis": "^1.0.3",
 				"gopd": "^1.0.1",
-				"has": "^1.0.3",
-				"has-property-descriptors": "^1.0.0",
-				"has-proto": "^1.0.1",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
 				"has-symbols": "^1.0.3",
-				"internal-slot": "^1.0.4",
-				"is-array-buffer": "^3.0.1",
+				"hasown": "^2.0.2",
+				"internal-slot": "^1.0.7",
+				"is-array-buffer": "^3.0.4",
 				"is-callable": "^1.2.7",
-				"is-negative-zero": "^2.0.2",
+				"is-data-view": "^1.0.1",
+				"is-negative-zero": "^2.0.3",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.2",
+				"is-shared-array-buffer": "^1.0.3",
 				"is-string": "^1.0.7",
-				"is-typed-array": "^1.1.10",
+				"is-typed-array": "^1.1.13",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.2",
+				"object-inspect": "^1.13.1",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.4",
-				"regexp.prototype.flags": "^1.4.3",
-				"safe-regex-test": "^1.0.0",
-				"string.prototype.trimend": "^1.0.6",
-				"string.prototype.trimstart": "^1.0.6",
-				"typed-array-length": "^1.0.4",
+				"object.assign": "^4.1.5",
+				"regexp.prototype.flags": "^1.5.2",
+				"safe-array-concat": "^1.1.2",
+				"safe-regex-test": "^1.0.3",
+				"string.prototype.trim": "^1.2.9",
+				"string.prototype.trimend": "^1.0.8",
+				"string.prototype.trimstart": "^1.0.8",
+				"typed-array-buffer": "^1.0.2",
+				"typed-array-byte-length": "^1.0.1",
+				"typed-array-byte-offset": "^1.0.2",
+				"typed-array-length": "^1.0.6",
 				"unbox-primitive": "^1.0.2",
-				"which-typed-array": "^1.1.9"
+				"which-typed-array": "^1.1.15"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6792,34 +7100,92 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-iterator-helpers": {
+			"version": "1.0.19",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.19.tgz",
+			"integrity": "sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3",
+				"es-errors": "^1.3.0",
+				"es-set-tostringtag": "^2.0.3",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"globalthis": "^1.0.3",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.7",
+				"iterator.prototype": "^1.1.2",
+				"safe-array-concat": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-module-lexer": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+			"integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/es-set-tostringtag": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-			"integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+		"node_modules/es-object-atoms": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.1.3",
-				"has": "^1.0.3",
-				"has-tostringtag": "^1.0.0"
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.4",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
 		"node_modules/es-shim-unscopables": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-			"integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
 			"dev": true,
 			"dependencies": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.0"
 			}
 		},
 		"node_modules/es-to-primitive": {
@@ -6855,9 +7221,9 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -7026,10 +7392,37 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint-compat-utils": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+			"integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"eslint": ">=6.0.0"
+			}
+		},
+		"node_modules/eslint-compat-utils/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/eslint-config-prettier": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
-			"integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+			"integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
 			"dev": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
@@ -7091,36 +7484,126 @@
 			}
 		},
 		"node_modules/eslint-formatter-pretty": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
-			"integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-6.0.1.tgz",
+			"integrity": "sha512-znAUcXmBthdIUmlnRkPSxz3zSJHFUhfHF/nJPcCMVKg/mOa4yUie2Olqg1Ghbi5JJRBZVU3rIgzWSObvIspxMA==",
 			"dev": true,
 			"dependencies": {
-				"@types/eslint": "^7.2.13",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.1.0",
-				"eslint-rule-docs": "^1.1.5",
-				"log-symbols": "^4.0.0",
-				"plur": "^4.0.0",
-				"string-width": "^4.2.0",
-				"supports-hyperlinks": "^2.0.0"
+				"@types/eslint": "^8.44.6",
+				"ansi-escapes": "^6.2.0",
+				"chalk": "^5.3.0",
+				"eslint-rule-docs": "^1.1.235",
+				"log-symbols": "^6.0.0",
+				"plur": "^5.1.0",
+				"string-width": "^7.0.0",
+				"supports-hyperlinks": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-formatter-pretty/node_modules/ansi-escapes": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+			"integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-formatter-pretty/node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/eslint-formatter-pretty/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/eslint-formatter-pretty/node_modules/emoji-regex": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+			"dev": true
+		},
+		"node_modules/eslint-formatter-pretty/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-formatter-pretty/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/eslint-formatter-pretty/node_modules/supports-hyperlinks": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.1.0.tgz",
+			"integrity": "sha512-2rn0BZ+/f7puLOHZm1HOJfwBggfaHXUpPUSSG/SWM4TWp5KCfmNYwnC3hruy2rZlMnmWZ+QAGpZfchu3f3695A==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint-import-resolver-node": {
-			"version": "0.3.7",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
-			"integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+			"integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^3.2.7",
-				"is-core-module": "^2.11.0",
-				"resolve": "^1.22.1"
+				"is-core-module": "^2.13.0",
+				"resolve": "^1.22.4"
 			}
 		},
 		"node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -7133,22 +7616,21 @@
 			}
 		},
 		"node_modules/eslint-import-resolver-webpack": {
-			"version": "0.13.2",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz",
-			"integrity": "sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==",
+			"version": "0.13.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.9.tgz",
+			"integrity": "sha512-yGngeefNiHXau2yzKKs2BNON4HLpxBabY40BGL/vUSKZtqzjlVsTTZm57jhHULhm+mJEwKsEIIN3NXup5AiiBQ==",
 			"dev": true,
 			"dependencies": {
-				"array-find": "^1.0.0",
 				"debug": "^3.2.7",
 				"enhanced-resolve": "^0.9.1",
 				"find-root": "^1.1.0",
-				"has": "^1.0.3",
+				"hasown": "^2.0.0",
 				"interpret": "^1.4.0",
-				"is-core-module": "^2.7.0",
+				"is-core-module": "^2.13.1",
 				"is-regex": "^1.1.4",
 				"lodash": "^4.17.21",
-				"resolve": "^1.20.0",
-				"semver": "^5.7.1"
+				"resolve": "^2.0.0-next.5",
+				"semver": "^5.7.2"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -7167,10 +7649,36 @@
 				"ms": "^2.1.1"
 			}
 		},
+		"node_modules/eslint-import-resolver-webpack/node_modules/resolve": {
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/eslint-import-resolver-webpack/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
 		"node_modules/eslint-module-utils": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
-			"integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.11.0.tgz",
+			"integrity": "sha512-gbBE5Hitek/oG6MUVj6sFuzEjA/ClzNflVrLovHi/JgLdC7fiN5gLAY1WIPW1a0V5I999MnsrvVrCOGmmVqDBQ==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^3.2.7"
@@ -7194,9 +7702,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-ava": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
-			"integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-14.0.0.tgz",
+			"integrity": "sha512-XmKT6hppaipwwnLVwwvQliSU6AF1QMHiNoLD5JQfzhUhf0jY7CO0O624fQrE+Y/fTb9vbW8r77nKf7M/oHulxw==",
 			"dev": true,
 			"dependencies": {
 				"enhance-visitors": "^1.0.0",
@@ -7209,10 +7717,10 @@
 				"resolve-from": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=12.22 <13 || >=14.17 <15 || >=16.4"
+				"node": ">=14.17 <15 || >=16.4"
 			},
 			"peerDependencies": {
-				"eslint": ">=7.22.0"
+				"eslint": ">=8.26.0"
 			}
 		},
 		"node_modules/eslint-plugin-ava/node_modules/pkg-dir": {
@@ -7236,47 +7744,25 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/eslint-plugin-es": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-			"integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+		"node_modules/eslint-plugin-es-x": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+			"integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
 			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/ota-meshi",
+				"https://opencollective.com/eslint"
+			],
 			"dependencies": {
-				"eslint-utils": "^2.0.0",
-				"regexpp": "^3.0.0"
+				"@eslint-community/eslint-utils": "^4.1.2",
+				"@eslint-community/regexpp": "^4.11.0",
+				"eslint-compat-utils": "^0.5.1"
 			},
 			"engines": {
-				"node": ">=8.10.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
+				"node": "^14.18.0 || >=16.0.0"
 			},
 			"peerDependencies": {
-				"eslint": ">=4.19.1"
-			}
-		},
-		"node_modules/eslint-plugin-es/node_modules/eslint-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-			"dev": true,
-			"dependencies": {
-				"eslint-visitor-keys": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
-		"node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
+				"eslint": ">=8"
 			}
 		},
 		"node_modules/eslint-plugin-eslint-comments": {
@@ -7308,26 +7794,29 @@
 			}
 		},
 		"node_modules/eslint-plugin-import": {
-			"version": "2.27.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
-			"integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
+			"integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
 			"dev": true,
 			"dependencies": {
-				"array-includes": "^3.1.6",
-				"array.prototype.flat": "^1.3.1",
-				"array.prototype.flatmap": "^1.3.1",
+				"@rtsao/scc": "^1.1.0",
+				"array-includes": "^3.1.8",
+				"array.prototype.findlastindex": "^1.2.5",
+				"array.prototype.flat": "^1.3.2",
+				"array.prototype.flatmap": "^1.3.2",
 				"debug": "^3.2.7",
 				"doctrine": "^2.1.0",
-				"eslint-import-resolver-node": "^0.3.7",
-				"eslint-module-utils": "^2.7.4",
-				"has": "^1.0.3",
-				"is-core-module": "^2.11.0",
+				"eslint-import-resolver-node": "^0.3.9",
+				"eslint-module-utils": "^2.9.0",
+				"hasown": "^2.0.2",
+				"is-core-module": "^2.15.1",
 				"is-glob": "^4.0.3",
 				"minimatch": "^3.1.2",
-				"object.values": "^1.1.6",
-				"resolve": "^1.22.1",
-				"semver": "^6.3.0",
-				"tsconfig-paths": "^3.14.1"
+				"object.fromentries": "^2.0.8",
+				"object.groupby": "^1.0.3",
+				"object.values": "^1.2.0",
+				"semver": "^6.3.1",
+				"tsconfig-paths": "^3.15.0"
 			},
 			"engines": {
 				"node": ">=4"
@@ -7358,12 +7847,107 @@
 			}
 		},
 		"node_modules/eslint-plugin-import/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/eslint-plugin-n": {
+			"version": "17.10.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.10.3.tgz",
+			"integrity": "sha512-ySZBfKe49nQZWR1yFaA0v/GsH6Fgp8ah6XV0WDz6CN8WO0ek4McMzb7A2xnf4DCYV43frjCygvb9f/wx7UUxRw==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"enhanced-resolve": "^5.17.0",
+				"eslint-plugin-es-x": "^7.5.0",
+				"get-tsconfig": "^4.7.0",
+				"globals": "^15.8.0",
+				"ignore": "^5.2.4",
+				"minimatch": "^9.0.5",
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.23.0"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/enhanced-resolve": {
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/globals": {
+			"version": "15.9.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
+			"integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/eslint-plugin-no-unsanitized": {
@@ -7390,113 +7974,87 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/eslint-plugin-node": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-			"integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+		"node_modules/eslint-plugin-prettier": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
+			"integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
 			"dev": true,
 			"dependencies": {
-				"eslint-plugin-es": "^3.0.0",
-				"eslint-utils": "^2.0.0",
-				"ignore": "^5.1.1",
-				"minimatch": "^3.0.4",
-				"resolve": "^1.10.1",
-				"semver": "^6.1.0"
+				"prettier-linter-helpers": "^1.0.0",
+				"synckit": "^0.9.1"
 			},
 			"engines": {
-				"node": ">=8.10.0"
-			},
-			"peerDependencies": {
-				"eslint": ">=5.16.0"
-			}
-		},
-		"node_modules/eslint-plugin-node/node_modules/eslint-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-			"dev": true,
-			"dependencies": {
-				"eslint-visitor-keys": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=6"
+				"node": "^14.18.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
-		"node_modules/eslint-plugin-node/node_modules/eslint-visitor-keys": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-plugin-node/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/eslint-plugin-prettier": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-			"integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
-			"dev": true,
-			"dependencies": {
-				"prettier-linter-helpers": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
+				"url": "https://opencollective.com/eslint-plugin-prettier"
 			},
 			"peerDependencies": {
-				"eslint": ">=7.28.0",
-				"prettier": ">=2.0.0"
+				"@types/eslint": ">=8.0.0",
+				"eslint": ">=8.0.0",
+				"eslint-config-prettier": "*",
+				"prettier": ">=3.0.0"
 			},
 			"peerDependenciesMeta": {
+				"@types/eslint": {
+					"optional": true
+				},
 				"eslint-config-prettier": {
 					"optional": true
 				}
 			}
 		},
+		"node_modules/eslint-plugin-promise": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
+			"integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+			}
+		},
 		"node_modules/eslint-plugin-react": {
-			"version": "7.32.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
-			"integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
+			"version": "7.36.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.36.1.tgz",
+			"integrity": "sha512-/qwbqNXZoq+VP30s1d4Nc1C5GTxjJQjk4Jzs4Wq2qzxFM7dSmuG2UkIjg2USMLh3A/aVcUNrK7v0J5U1XEGGwA==",
 			"dev": true,
 			"dependencies": {
-				"array-includes": "^3.1.6",
-				"array.prototype.flatmap": "^1.3.1",
-				"array.prototype.tosorted": "^1.1.1",
+				"array-includes": "^3.1.8",
+				"array.prototype.findlast": "^1.2.5",
+				"array.prototype.flatmap": "^1.3.2",
+				"array.prototype.tosorted": "^1.1.4",
 				"doctrine": "^2.1.0",
+				"es-iterator-helpers": "^1.0.19",
 				"estraverse": "^5.3.0",
+				"hasown": "^2.0.2",
 				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 				"minimatch": "^3.1.2",
-				"object.entries": "^1.1.6",
-				"object.fromentries": "^2.0.6",
-				"object.hasown": "^1.1.2",
-				"object.values": "^1.1.6",
+				"object.entries": "^1.1.8",
+				"object.fromentries": "^2.0.8",
+				"object.values": "^1.2.0",
 				"prop-types": "^15.8.1",
-				"resolve": "^2.0.0-next.4",
-				"semver": "^6.3.0",
-				"string.prototype.matchall": "^4.0.8"
+				"resolve": "^2.0.0-next.5",
+				"semver": "^6.3.1",
+				"string.prototype.matchall": "^4.0.11",
+				"string.prototype.repeat": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=4"
 			},
 			"peerDependencies": {
-				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-			"integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+			"integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"
@@ -7527,12 +8085,12 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/resolve": {
-			"version": "2.0.0-next.4",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
-			"integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
 			"dev": true,
 			"dependencies": {
-				"is-core-module": "^2.9.0",
+				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -7544,77 +8102,13 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
-		},
-		"node_modules/eslint-plugin-unicorn": {
-			"version": "40.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-40.1.0.tgz",
-			"integrity": "sha512-y5doK2DF9Sr5AqKEHbHxjFllJ167nKDRU01HDcWyv4Tnmaoe9iNxMrBnaybZvWZUaE3OC5Unu0lNIevYamloig==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.15.7",
-				"ci-info": "^3.3.0",
-				"clean-regexp": "^1.0.0",
-				"eslint-utils": "^3.0.0",
-				"esquery": "^1.4.0",
-				"indent-string": "^4.0.0",
-				"is-builtin-module": "^3.1.0",
-				"lodash": "^4.17.21",
-				"pluralize": "^8.0.0",
-				"read-pkg-up": "^7.0.1",
-				"regexp-tree": "^0.1.24",
-				"safe-regex": "^2.1.1",
-				"semver": "^7.3.5",
-				"strip-indent": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
-			},
-			"peerDependencies": {
-				"eslint": ">=7.32.0"
-			}
-		},
-		"node_modules/eslint-plugin-unicorn/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/eslint-plugin-unicorn/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/eslint-plugin-unicorn/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
 		},
 		"node_modules/eslint-rule-docs": {
 			"version": "1.1.235",
@@ -7746,10 +8240,14 @@
 			}
 		},
 		"node_modules/esm-utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-2.2.0.tgz",
-			"integrity": "sha512-kYj4yNRo4W3by0f1mj4AfRh1nsRTTpQG921Ik3AfyUq6upGlkI1fnMLypHn6XtFzZPdCYH1k9mtQA5MyZF9m+w==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-4.3.0.tgz",
+			"integrity": "sha512-KupZztbWAnuksy1TYPjTkePxVlMWzmXdmB72z1WvUadtUiFv6x+0PKjYfyy1io9gdvU1A6QIcu055NRrJu1TEA==",
 			"dev": true,
+			"dependencies": {
+				"import-meta-resolve": "^4.1.0",
+				"url-or-path": "^2.3.0"
+			},
 			"funding": {
 				"url": "https://github.com/fisker/esm-utils?sponsor=1"
 			}
@@ -8033,15 +8531,15 @@
 			"dev": true
 		},
 		"node_modules/fast-diff": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.12",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -8167,6 +8665,33 @@
 				"node": "^12.20 || >= 14.13"
 			}
 		},
+		"node_modules/figures": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+			"integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+			"dev": true,
+			"dependencies": {
+				"is-unicode-supported": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/figures/node_modules/is-unicode-supported": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -8180,9 +8705,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -8192,20 +8717,116 @@
 			}
 		},
 		"node_modules/find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-5.0.0.tgz",
+			"integrity": "sha512-OuWNfjfP05JcpAP3JPgAKUhWefjMRfI5iAoSsvE24ANYWJaepAtlSgWECSVEuRgSXpyNEc9DJwG/TZpgcOqyig==",
 			"dev": true,
 			"dependencies": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
+				"common-path-prefix": "^3.0.0",
+				"pkg-dir": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16"
 			},
 			"funding": {
-				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/find-up": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+			"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^7.1.0",
+				"path-exists": "^5.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/locate-path": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+			"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^6.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/p-limit": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^1.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/p-locate": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/path-exists": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+			"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/pkg-dir": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+			"integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/yocto-queue": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+			"integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/find-file-up": {
@@ -8273,6 +8894,18 @@
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-up-simple": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+			"integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -8485,21 +9118,24 @@
 			}
 		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/function.prototype.name": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.0",
-				"functions-have-names": "^1.2.2"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8618,15 +9254,32 @@
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
-		"node_modules/get-intrinsic": {
+		"node_modules/get-east-asian-width": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-			"integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+			"integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
 			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.3"
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -8684,19 +9337,32 @@
 			}
 		},
 		"node_modules/get-symbol-description": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+			"integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.1"
+				"call-bind": "^1.0.5",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
+			"integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+			"dev": true,
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
 		"node_modules/getpass": {
@@ -8907,6 +9573,12 @@
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
 		},
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
+		},
 		"node_modules/growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -8945,18 +9617,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"dependencies": {
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/has-bigints": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -8976,21 +9636,21 @@
 			}
 		},
 		"node_modules/has-property-descriptors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.1.1"
+				"es-define-property": "^1.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
@@ -9012,12 +9672,12 @@
 			}
 		},
 		"node_modules/has-tostringtag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
 			"dev": true,
 			"dependencies": {
-				"has-symbols": "^1.0.2"
+				"has-symbols": "^1.0.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -9036,6 +9696,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/homedir-polyfill": {
@@ -9267,9 +9939,9 @@
 			]
 		},
 		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -9340,6 +10012,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+			"integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/import-modules": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
@@ -9393,13 +10075,13 @@
 			"dev": true
 		},
 		"node_modules/internal-slot": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
-			"integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.1.3",
-				"has": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"hasown": "^2.0.0",
 				"side-channel": "^1.0.4"
 			},
 			"engines": {
@@ -9433,9 +10115,9 @@
 			}
 		},
 		"node_modules/irregular-plurals": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.4.0.tgz",
-			"integrity": "sha512-YXxECO/W6N9aMBVKMKKZ8TXESgq7EFrp3emCGGUcrYY1cgJIeZjoB75MTu8qi+NAKntS9NwPU8VdcQ3r6E6aWQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+			"integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
@@ -9455,14 +10137,16 @@
 			}
 		},
 		"node_modules/is-array-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-			"integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.3",
-				"is-typed-array": "^1.1.10"
+				"get-intrinsic": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -9473,6 +10157,21 @@
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true
+		},
+		"node_modules/is-async-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+			"integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/is-bigint": {
 			"version": "1.0.4",
@@ -9503,9 +10202,9 @@
 			}
 		},
 		"node_modules/is-builtin-module": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
-			"integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+			"integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
 			"dev": true,
 			"dependencies": {
 				"builtin-modules": "^3.3.0"
@@ -9542,12 +10241,30 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+			"integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
 			"dev": true,
 			"dependencies": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-data-view": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+			"integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+			"dev": true,
+			"dependencies": {
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -9592,6 +10309,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-finalizationregistry": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+			"integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -9608,6 +10337,21 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/is-generator-function": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-get-set-prop": {
@@ -9641,6 +10385,39 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-installed-globally": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
@@ -9672,6 +10449,18 @@
 			"integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
 			"dev": true
 		},
+		"node_modules/is-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+			"integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-mergeable-object": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.1.tgz",
@@ -9688,9 +10477,9 @@
 			}
 		},
 		"node_modules/is-negative-zero": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
@@ -9843,13 +10632,28 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-set": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+			"integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-shared-array-buffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2"
+				"call-bind": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -9898,16 +10702,12 @@
 			}
 		},
 		"node_modules/is-typed-array": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-			"integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
 			"dev": true,
 			"dependencies": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0"
+				"which-typed-array": "^1.1.14"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -9935,12 +10735,12 @@
 			}
 		},
 		"node_modules/is-unicode-supported": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -9952,6 +10752,18 @@
 			"integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
 			"dev": true
 		},
+		"node_modules/is-weakmap": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+			"integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-weakref": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -9959,6 +10771,22 @@
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
+			"integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -9993,6 +10821,12 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -10079,6 +10913,19 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/iterator.prototype": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
+			"integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
+			"dev": true,
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"get-intrinsic": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"reflect.getprototypeof": "^1.0.4",
+				"set-function-name": "^2.0.1"
 			}
 		},
 		"node_modules/jed": {
@@ -12224,19 +13071,31 @@
 			"dev": true
 		},
 		"node_modules/log-symbols": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+			"integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
 			"dev": true,
 			"dependencies": {
-				"chalk": "^4.1.0",
-				"is-unicode-supported": "^0.1.0"
+				"chalk": "^5.3.0",
+				"is-unicode-supported": "^1.3.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-symbols/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/loose-envify": {
@@ -12505,12 +13364,12 @@
 			"dev": true
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -13006,9 +13865,9 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-			"integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
 			"dev": true
 		},
 		"node_modules/normalize-package-data": {
@@ -13249,10 +14108,13 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
 			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -13267,13 +14129,13 @@
 			}
 		},
 		"node_modules/object.assign": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
 				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
 			},
@@ -13285,28 +14147,29 @@
 			}
 		},
 		"node_modules/object.entries": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
-			"integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
+			"integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
 		"node_modules/object.fromentries": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
-			"integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+			"integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-object-atoms": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13315,28 +14178,29 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/object.hasown": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
-			"integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+		"node_modules/object.groupby": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+			"integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
 			"dev": true,
 			"dependencies": {
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2"
 			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/object.values": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
-			"integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
+			"integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13393,27 +14257,199 @@
 			}
 		},
 		"node_modules/open-editor": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/open-editor/-/open-editor-4.0.0.tgz",
-			"integrity": "sha512-5mKZ98iFdkivozt5XTCOspoKbL3wtYu6oOoVxfWQ0qUX9NYsK8pdkHE7VUHXr+CwyC3nf6mV0S5FPsMS65innw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/open-editor/-/open-editor-5.0.0.tgz",
+			"integrity": "sha512-fRHi4my03WQSbWfqChs9AdFfSp6SLalB3zadfwfYIojoKanLDBfv2uAdiZCfzdvom7TBdlXu2UeiiydBc56/EQ==",
 			"dev": true,
 			"dependencies": {
-				"env-editor": "^1.0.0",
-				"execa": "^5.1.1",
+				"env-editor": "^1.1.0",
+				"execa": "^9.3.0",
 				"line-column-path": "^3.0.0",
-				"open": "^8.4.0"
+				"open": "^10.1.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/execa": {
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-9.4.0.tgz",
+			"integrity": "sha512-yKHlle2YGxZE842MERVIplWwNH5VYmqqcPFgtnlU//K8gxuFFXu0pwd/CrfXTumFpeEiufsP7+opT/bPJa1yVw==",
+			"dev": true,
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^4.0.0",
+				"cross-spawn": "^7.0.3",
+				"figures": "^6.1.0",
+				"get-stream": "^9.0.0",
+				"human-signals": "^8.0.0",
+				"is-plain-obj": "^4.1.0",
+				"is-stream": "^4.0.1",
+				"npm-run-path": "^6.0.0",
+				"pretty-ms": "^9.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^4.0.0",
+				"yoctocolors": "^2.0.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.5.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/open-editor/node_modules/get-stream": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+			"dev": true,
+			"dependencies": {
+				"@sec-ant/readable-stream": "^0.4.1",
+				"is-stream": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/human-signals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
+			"integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/open-editor/node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/is-stream": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/is-wsl": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"dev": true,
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/npm-run-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+			"integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^4.0.0",
+				"unicorn-magic": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/open": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+			"integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+			"dev": true,
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/open-editor/node_modules/strip-final-newline": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/optionator": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
@@ -13421,7 +14457,7 @@
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
 				"type-check": "^0.4.0",
-				"word-wrap": "^1.2.3"
+				"word-wrap": "^1.2.5"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -13709,6 +14745,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/parse-ms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+			"integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -13877,9 +14925,9 @@
 			"dev": true
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+			"integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
 			"dev": true
 		},
 		"node_modules/picomatch": {
@@ -14066,15 +15114,15 @@
 			}
 		},
 		"node_modules/plur": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
-			"integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-5.1.0.tgz",
+			"integrity": "sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==",
 			"dev": true,
 			"dependencies": {
-				"irregular-plurals": "^3.2.0"
+				"irregular-plurals": "^3.3.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -14087,6 +15135,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/postcss": {
@@ -14219,15 +15276,15 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-			"integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+			"integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
 			"dev": true,
 			"bin": {
-				"prettier": "bin-prettier.js"
+				"prettier": "bin/prettier.cjs"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
@@ -14269,6 +15326,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/pretty-ms": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.1.0.tgz",
+			"integrity": "sha512-o1piW0n3tgKIKCwk2vpM/vOV13zjJzvP37Ioze54YlTHE06m4tjEbzg9WsKkvTuyYln2DHjo5pY4qrZGI0otpw==",
+			"dev": true,
+			"dependencies": {
+				"parse-ms": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/process": {
@@ -14807,6 +15879,27 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/reflect.getprototypeof": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
+			"integrity": "sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.1",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"globalthis": "^1.0.3",
+				"which-builtin-type": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/regenerator-runtime": {
 			"version": "0.13.11",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -14814,23 +15907,24 @@
 			"dev": true
 		},
 		"node_modules/regexp-tree": {
-			"version": "0.1.24",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
-			"integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+			"integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
 			"dev": true,
 			"bin": {
 				"regexp-tree": "bin/regexp-tree"
 			}
 		},
 		"node_modules/regexp.prototype.flags": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-			"integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+			"integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"functions-have-names": "^1.2.2"
+				"call-bind": "^1.0.6",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"set-function-name": "^2.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -14876,6 +15970,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/regjsparser": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.10.0.tgz",
+			"integrity": "sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==",
+			"dev": true,
+			"dependencies": {
+				"jsesc": "~0.5.0"
+			},
+			"bin": {
+				"regjsparser": "bin/parser"
+			}
+		},
+		"node_modules/regjsparser/node_modules/jsesc": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+			"integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+			"dev": true,
+			"bin": {
+				"jsesc": "bin/jsesc"
 			}
 		},
 		"node_modules/relaxed-json": {
@@ -15060,12 +16175,12 @@
 			"dev": true
 		},
 		"node_modules/resolve": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
 			"dev": true,
 			"dependencies": {
-				"is-core-module": "^2.9.0",
+				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -15162,6 +16277,15 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/resolve.exports": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.0.tgz",
@@ -15211,6 +16335,18 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/run-applescript": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+			"integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -15243,6 +16379,24 @@
 				"tslib": "^2.1.0"
 			}
 		},
+		"node_modules/safe-array-concat": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+			"integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4",
+				"has-symbols": "^1.0.3",
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">=0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -15270,24 +16424,18 @@
 			"dev": true,
 			"optional": true
 		},
-		"node_modules/safe-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
-			"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
-			"dev": true,
-			"dependencies": {
-				"regexp-tree": "~0.1.1"
-			}
-		},
 		"node_modules/safe-regex-test": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+			"integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.3",
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
 				"is-regex": "^1.1.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -15335,9 +16483,9 @@
 			}
 		},
 		"node_modules/schema-utils": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -15411,9 +16559,9 @@
 			"dev": true
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-			"integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -15455,6 +16603,38 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-function-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/setimmediate": {
@@ -15513,14 +16693,18 @@
 			"dev": true
 		},
 		"node_modules/side-channel": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.0",
-				"get-intrinsic": "^1.0.2",
-				"object-inspect": "^1.9.0"
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -15860,19 +17044,26 @@
 			}
 		},
 		"node_modules/string.prototype.matchall": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
-			"integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
+			"integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"get-intrinsic": "^1.1.3",
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
 				"has-symbols": "^1.0.3",
-				"internal-slot": "^1.0.3",
-				"regexp.prototype.flags": "^1.4.3",
-				"side-channel": "^1.0.4"
+				"internal-slot": "^1.0.7",
+				"regexp.prototype.flags": "^1.5.2",
+				"set-function-name": "^2.0.2",
+				"side-channel": "^1.0.6"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -15895,29 +17086,60 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/string.prototype.trimend": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-			"integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+		"node_modules/string.prototype.repeat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+			"integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			}
+		},
+		"node_modules/string.prototype.trim": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+			"integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.0",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimend": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+			"integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-			"integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+			"integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -16187,6 +17409,22 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
+		"node_modules/synckit": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
+			"integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
+			"dev": true,
+			"dependencies": {
+				"@pkgr/core": "^0.1.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts"
+			}
+		},
 		"node_modules/table": {
 			"version": "6.8.1",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -16275,13 +17513,13 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.16.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-			"integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.33.0.tgz",
+			"integrity": "sha512-JuPVaB7s1gdFKPKTelwUyRq5Sid2A3Gko2S0PncwdBq7kN9Ti9HPWDQ06MPsEDGsZeVESjKEnyGy68quBk1w6g==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/source-map": "^0.3.2",
-				"acorn": "^8.5.0",
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			},
@@ -16293,17 +17531,17 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.6",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
-			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+			"version": "5.3.10",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+			"integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.14",
+				"@jridgewell/trace-mapping": "^0.3.20",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.0",
-				"terser": "^5.14.1"
+				"serialize-javascript": "^6.0.1",
+				"terser": "^5.26.0"
 			},
 			"engines": {
 				"node": ">= 10.13.0"
@@ -16422,9 +17660,9 @@
 			"dev": true
 		},
 		"node_modules/to-absolute-glob": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha512-rtwLUQEwT8ZeKQbyFJyomBRYXyE16U5VKuy0ftxLMK/PZb2fkOsg5r9kHdauuVDbsNdIBoC/HCthpidamQFXYA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-3.0.0.tgz",
+			"integrity": "sha512-loO/XEWTRqpfcpI7+Jr2RR2Umaaozx1t6OSVWtMi0oy5F/Fxg3IC+D/TToDnxyAGs7uZBGT/6XmyDUxgsObJXA==",
 			"dev": true,
 			"dependencies": {
 				"is-absolute": "^1.0.0",
@@ -16516,6 +17754,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/ts-api-utils": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
 			}
 		},
 		"node_modules/ts-jest": {
@@ -16673,13 +17923,13 @@
 			}
 		},
 		"node_modules/tsconfig-paths": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-			"integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+			"integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
 			"dev": true,
 			"dependencies": {
 				"@types/json5": "^0.0.29",
-				"json5": "^1.0.1",
+				"json5": "^1.0.2",
 				"minimist": "^1.2.6",
 				"strip-bom": "^3.0.0"
 			}
@@ -16706,9 +17956,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -16782,15 +18032,74 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/typed-array-length": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
-			"integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/typed-array-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+			"integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
 				"for-each": "^0.3.3",
-				"is-typed-array": "^1.1.9"
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-byte-offset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+			"integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-length": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+			"integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13",
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -16858,6 +18167,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/unicorn-magic": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/unique-string": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
@@ -16884,9 +18205,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+			"integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -16896,14 +18217,18 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.1.2",
+				"picocolors": "^1.0.1"
 			},
 			"bin": {
-				"browserslist-lint": "cli.js"
+				"update-browserslist-db": "cli.js"
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
@@ -16989,6 +18314,15 @@
 			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/url-or-path": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/url-or-path/-/url-or-path-2.3.0.tgz",
+			"integrity": "sha512-5g9xpEJKjbAY8ikLU3XFpEg3hRLGt6SbCQmDElb1AL7JTW6vMi5Na5e3dMvONHisIu9VHgMAADLHJ8EznYR2ow==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/fisker/url-or-path?sponsor=1"
 			}
 		},
 		"node_modules/url-parse": {
@@ -17363,35 +18697,34 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.76.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
-			"integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
+			"version": "5.94.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+			"integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@types/eslint-scope": "^3.7.3",
-				"@types/estree": "^0.0.51",
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/wasm-edit": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
+				"@types/estree": "^1.0.5",
+				"@webassemblyjs/ast": "^1.12.1",
+				"@webassemblyjs/wasm-edit": "^1.12.1",
+				"@webassemblyjs/wasm-parser": "^1.12.1",
 				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.7.6",
-				"browserslist": "^4.14.5",
+				"acorn-import-attributes": "^1.9.5",
+				"browserslist": "^4.21.10",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.10.0",
-				"es-module-lexer": "^0.9.0",
+				"enhanced-resolve": "^5.17.1",
+				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
-				"graceful-fs": "^4.2.9",
+				"graceful-fs": "^4.2.11",
 				"json-parse-even-better-errors": "^2.3.1",
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.1.0",
+				"schema-utils": "^3.2.0",
 				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.1.3",
-				"watchpack": "^2.4.0",
+				"terser-webpack-plugin": "^5.3.10",
+				"watchpack": "^2.4.1",
 				"webpack-sources": "^3.2.3"
 			},
 			"bin": {
@@ -17420,17 +18753,10 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/webpack/node_modules/@types/estree": {
-			"version": "0.0.51",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/webpack/node_modules/enhanced-resolve": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
-			"integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -17441,6 +18767,13 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/webpack/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/webpack/node_modules/tapable": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -17449,6 +18782,20 @@
 			"peer": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/webpack/node_modules/watchpack": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/whatwg-encoding": {
@@ -17519,18 +18866,61 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/which-typed-array": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-			"integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+		"node_modules/which-builtin-type": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.4.tgz",
+			"integrity": "sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==",
 			"dev": true,
 			"dependencies": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
+				"function.prototype.name": "^1.1.6",
+				"has-tostringtag": "^1.0.2",
+				"is-async-function": "^2.0.0",
+				"is-date-object": "^1.0.5",
+				"is-finalizationregistry": "^1.0.2",
+				"is-generator-function": "^1.0.10",
+				"is-regex": "^1.1.4",
+				"is-weakref": "^1.0.2",
+				"isarray": "^2.0.5",
+				"which-boxed-primitive": "^1.0.2",
+				"which-collection": "^1.0.2",
+				"which-typed-array": "^1.1.15"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-collection": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+			"integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+			"dev": true,
+			"dependencies": {
+				"is-map": "^2.0.3",
+				"is-set": "^2.0.3",
+				"is-weakmap": "^2.0.2",
+				"is-weakset": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+			"integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
 				"for-each": "^0.3.3",
 				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0",
-				"is-typed-array": "^1.1.10"
+				"has-tostringtag": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -17611,9 +19001,9 @@
 			"dev": true
 		},
 		"node_modules/word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -17787,130 +19177,128 @@
 			"dev": true
 		},
 		"node_modules/xo": {
-			"version": "0.48.0",
-			"resolved": "https://registry.npmjs.org/xo/-/xo-0.48.0.tgz",
-			"integrity": "sha512-f0sbQGJoML3nwOLG7EIAJroBypmLokoGJqTPN+bI/oogKLMciqWBEiFh9Vpxnfwxafq1AkHoWrQZQWSflDCG1w==",
-			"bundleDependencies": [
-				"@typescript-eslint/eslint-plugin",
-				"@typescript-eslint/parser",
-				"eslint-config-xo-typescript"
-			],
+			"version": "0.59.3",
+			"resolved": "https://registry.npmjs.org/xo/-/xo-0.59.3.tgz",
+			"integrity": "sha512-jjUplAF4kqNP22HIlgnW+Ej8/Z1utf4Mzw/dLsbOcSpnUgrEqcyaS/OhGFriFyEBbnWVkslnYgUHiDsb6lNiBQ==",
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.0.5",
-				"@typescript-eslint/eslint-plugin": "*",
-				"@typescript-eslint/parser": "*",
+				"@eslint/eslintrc": "^3.1.0",
+				"@typescript-eslint/eslint-plugin": "^7.16.1",
+				"@typescript-eslint/parser": "^7.16.1",
 				"arrify": "^3.0.0",
-				"cosmiconfig": "^7.0.1",
+				"cosmiconfig": "^9.0.0",
 				"define-lazy-prop": "^3.0.0",
-				"eslint": "^8.8.0",
-				"eslint-config-prettier": "^8.3.0",
-				"eslint-config-xo": "^0.40.0",
-				"eslint-config-xo-typescript": "*",
-				"eslint-formatter-pretty": "^4.1.0",
-				"eslint-import-resolver-webpack": "^0.13.2",
-				"eslint-plugin-ava": "^13.2.0",
+				"eslint": "^8.57.0",
+				"eslint-config-prettier": "^9.1.0",
+				"eslint-config-xo": "^0.45.0",
+				"eslint-config-xo-typescript": "^5.0.0",
+				"eslint-formatter-pretty": "^6.0.1",
+				"eslint-import-resolver-webpack": "^0.13.8",
+				"eslint-plugin-ava": "^14.0.0",
 				"eslint-plugin-eslint-comments": "^3.2.0",
-				"eslint-plugin-import": "^2.25.4",
+				"eslint-plugin-import": "^2.29.1",
+				"eslint-plugin-n": "^17.9.0",
 				"eslint-plugin-no-use-extend-native": "^0.5.0",
-				"eslint-plugin-node": "^11.1.0",
-				"eslint-plugin-prettier": "^4.0.0",
-				"eslint-plugin-unicorn": "^40.1.0",
-				"esm-utils": "^2.0.1",
-				"find-cache-dir": "^3.3.2",
-				"find-up": "^6.3.0",
+				"eslint-plugin-prettier": "^5.2.1",
+				"eslint-plugin-promise": "^6.4.0",
+				"eslint-plugin-unicorn": "^54.0.0",
+				"esm-utils": "^4.3.0",
+				"find-cache-dir": "^5.0.0",
+				"find-up-simple": "^1.0.0",
 				"get-stdin": "^9.0.0",
-				"globby": "^13.1.1",
+				"get-tsconfig": "^4.7.5",
+				"globby": "^14.0.2",
 				"imurmurhash": "^0.1.4",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"json5": "^2.2.0",
 				"lodash-es": "^4.17.21",
-				"meow": "^10.1.2",
-				"micromatch": "^4.0.4",
-				"open-editor": "^4.0.0",
-				"prettier": "^2.5.1",
-				"semver": "^7.3.5",
-				"slash": "^4.0.0",
-				"to-absolute-glob": "^2.0.2",
-				"typescript": "^4.5.5"
+				"meow": "^13.2.0",
+				"micromatch": "^4.0.7",
+				"open-editor": "^5.0.0",
+				"prettier": "^3.3.3",
+				"semver": "^7.6.3",
+				"slash": "^5.1.0",
+				"to-absolute-glob": "^3.0.0",
+				"typescript": "^5.5.3"
 			},
 			"bin": {
 				"xo": "cli.js"
 			},
 			"engines": {
-				"node": ">=12.20"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/@nodelib/fs.scandir": {
-			"version": "2.1.5",
+		"node_modules/xo/node_modules/@eslint/js": {
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/xo/node_modules/@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/xo/node_modules/@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/xo/node_modules/@types/json-schema": {
-			"version": "7.0.9",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.11.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.11.0",
-				"@typescript-eslint/type-utils": "5.11.0",
-				"@typescript-eslint/utils": "5.11.0",
-				"debug": "^4.3.2",
-				"functional-red-black-tree": "^1.0.1",
-				"ignore": "^5.1.8",
-				"regexpp": "^3.2.0",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
-			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/xo/node_modules/@humanwhocodes/config-array": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+			"deprecated": "Use @eslint/config-array instead",
+			"dev": true,
+			"dependencies": {
+				"@humanwhocodes/object-schema": "^2.0.3",
+				"debug": "^4.3.1",
+				"minimatch": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/xo/node_modules/@humanwhocodes/object-schema": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
+			"dev": true
+		},
+		"node_modules/xo/node_modules/@sindresorhus/merge-streams": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/xo/node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+			"integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "7.18.0",
+				"@typescript-eslint/type-utils": "7.18.0",
+				"@typescript-eslint/utils": "7.18.0",
+				"@typescript-eslint/visitor-keys": "7.18.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.3.1",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^7.0.0",
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -17918,35 +19306,27 @@
 				}
 			}
 		},
-		"node_modules/xo/node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "5.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/xo/node_modules/@typescript-eslint/parser": {
-			"version": "5.11.0",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+			"integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
 			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.11.0",
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/typescript-estree": "5.11.0",
-				"debug": "^4.3.2"
+				"@typescript-eslint/scope-manager": "7.18.0",
+				"@typescript-eslint/types": "7.18.0",
+				"@typescript-eslint/typescript-estree": "7.18.0",
+				"@typescript-eslint/visitor-keys": "7.18.0",
+				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -17955,16 +19335,16 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.11.0",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+			"integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/visitor-keys": "5.11.0"
+				"@typescript-eslint/types": "7.18.0",
+				"@typescript-eslint/visitor-keys": "7.18.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -17972,24 +19352,25 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/type-utils": {
-			"version": "5.11.0",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+			"integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/utils": "5.11.0",
-				"debug": "^4.3.2",
-				"tsutils": "^3.21.0"
+				"@typescript-eslint/typescript-estree": "7.18.0",
+				"@typescript-eslint/utils": "7.18.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -17998,12 +19379,12 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/types": {
-			"version": "5.11.0",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+			"integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -18011,21 +19392,22 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.11.0",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+			"integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
 			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/visitor-keys": "5.11.0",
-				"debug": "^4.3.2",
-				"globby": "^11.0.4",
+				"@typescript-eslint/types": "7.18.0",
+				"@typescript-eslint/visitor-keys": "7.18.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -18039,9 +19421,9 @@
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
 			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
 			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
@@ -18057,72 +19439,67 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/ignore": {
-			"version": "5.2.0",
+		"node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
 			"engines": {
-				"node": ">= 4"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
 			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/utils": {
-			"version": "5.11.0",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+			"integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
 			"dependencies": {
-				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.11.0",
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/typescript-estree": "5.11.0",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@typescript-eslint/scope-manager": "7.18.0",
+				"@typescript-eslint/types": "7.18.0",
+				"@typescript-eslint/typescript-estree": "7.18.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.11.0",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+			"integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.11.0",
-				"eslint-visitor-keys": "^3.0.0"
+				"@typescript-eslint/types": "7.18.0",
+				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/xo/node_modules/array-union": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/xo/node_modules/arrify": {
@@ -18137,81 +19514,54 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/braces": {
-			"version": "3.0.2",
+		"node_modules/xo/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
 			"dependencies": {
-				"fill-range": "^7.0.1"
-			},
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/xo/node_modules/ci-info": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+			"integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
 			"engines": {
 				"node": ">=8"
 			}
 		},
-		"node_modules/xo/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/camelcase-keys": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
-			"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+		"node_modules/xo/node_modules/cosmiconfig": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
 			"dev": true,
 			"dependencies": {
-				"camelcase": "^6.3.0",
-				"map-obj": "^4.1.0",
-				"quick-lru": "^5.1.1",
-				"type-fest": "^1.2.1"
+				"env-paths": "^2.2.1",
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/debug": {
-			"version": "4.3.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
+				"url": "https://github.com/sponsors/d-fischer"
 			},
-			"engines": {
-				"node": ">=6.0"
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
 			},
 			"peerDependenciesMeta": {
-				"supports-color": {
+				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/xo/node_modules/debug/node_modules/ms": {
-			"version": "2.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/xo/node_modules/decamelize": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
-			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/xo/node_modules/define-lazy-prop": {
@@ -18226,626 +19576,268 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/dir-glob": {
-			"version": "3.0.1",
+		"node_modules/xo/node_modules/eslint": {
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
 			"dependencies": {
-				"path-type": "^4.0.0"
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.57.1",
+				"@humanwhocodes/config-array": "^0.13.0",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
+				"ajv": "^6.12.4",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
+				"debug": "^4.3.2",
+				"doctrine": "^3.0.0",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
+				"esquery": "^1.4.2",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^6.0.1",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"globals": "^13.19.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
+				"js-yaml": "^4.1.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.4.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.2",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3",
+				"strip-ansi": "^6.0.1",
+				"text-table": "^0.2.0"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/xo/node_modules/eslint-config-xo-typescript": {
-			"version": "0.50.0",
+		"node_modules/xo/node_modules/eslint-config-xo": {
+			"version": "0.45.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.45.0.tgz",
+			"integrity": "sha512-T30F2S2HKKmr/RoHopKE7wMUMWrsLMab1qFl2WyFJjETbD+l7p4hSQWpTVGW7TEbSKG1QBekwf6Jn9ZDPA6thA==",
 			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
+			"dependencies": {
+				"confusing-browser-globals": "1.0.11"
+			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": ">=5.8.0",
-				"eslint": ">=8.0.0",
-				"typescript": ">=4.4"
+				"eslint": ">=8.56.0"
+			}
+		},
+		"node_modules/xo/node_modules/eslint-config-xo-typescript": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-5.0.0.tgz",
+			"integrity": "sha512-ukAYCKf3p039pRai7hb6xaomZzsKlCjV5qx3NbYe27UC7Nz75If1HcpQL5sNW2b5aH8+Axb6dIIv28+bVtwlVQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/eslint-plugin": ">=7.16.0",
+				"@typescript-eslint/parser": ">=7.16.0",
+				"eslint": ">=8.56.0",
+				"typescript": ">=5.0.0"
+			}
+		},
+		"node_modules/xo/node_modules/eslint-plugin-unicorn": {
+			"version": "54.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-54.0.0.tgz",
+			"integrity": "sha512-XxYLRiYtAWiAjPv6z4JREby1TAE2byBC7wlh0V4vWDCpccOSU1KovWV//jqPXF6bq3WKxqX9rdjoRQ1EhdmNdQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.24.5",
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@eslint/eslintrc": "^3.0.2",
+				"ci-info": "^4.0.0",
+				"clean-regexp": "^1.0.0",
+				"core-js-compat": "^3.37.0",
+				"esquery": "^1.5.0",
+				"indent-string": "^4.0.0",
+				"is-builtin-module": "^3.2.1",
+				"jsesc": "^3.0.2",
+				"pluralize": "^8.0.0",
+				"read-pkg-up": "^7.0.1",
+				"regexp-tree": "^0.1.27",
+				"regjsparser": "^0.10.0",
+				"semver": "^7.6.1",
+				"strip-indent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.56.0"
 			}
 		},
 		"node_modules/xo/node_modules/eslint-scope": {
-			"version": "5.1.1",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
 				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/xo/node_modules/eslint-scope/node_modules/estraverse": {
-			"version": "4.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/xo/node_modules/eslint-utils": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			},
-			"peerDependencies": {
-				"eslint": ">=5"
-			}
-		},
-		"node_modules/xo/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/xo/node_modules/eslint-visitor-keys": {
-			"version": "3.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/xo/node_modules/esrecurse": {
-			"version": "4.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": ">=4.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/xo/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/xo/node_modules/eslint/node_modules/@eslint/eslintrc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^6.12.4",
+				"debug": "^4.3.2",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"minimatch": "^3.1.2",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/xo/node_modules/espree": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/xo/node_modules/estraverse": {
 			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/xo/node_modules/fast-glob": {
-			"version": "3.2.11",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.4"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/xo/node_modules/fastq": {
-			"version": "1.13.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"reusify": "^1.0.4"
-			}
-		},
-		"node_modules/xo/node_modules/fill-range": {
-			"version": "7.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/find-up": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-			"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^7.1.0",
-				"path-exists": "^5.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/functional-red-black-tree": {
-			"version": "1.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/xo/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/xo/node_modules/globby": {
-			"version": "13.1.3",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
-			"integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
 			"dev": true,
 			"dependencies": {
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.11",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^4.0.0"
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.2",
+				"ignore": "^5.2.4",
+				"path-type": "^5.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.1.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/hosted-git-info": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+		"node_modules/xo/node_modules/jsesc": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+			"integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
+			"bin": {
+				"jsesc": "bin/jsesc"
 			},
 			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/xo/node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/is-extglob": {
-			"version": "2.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/xo/node_modules/is-glob": {
-			"version": "4.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-extglob": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/xo/node_modules/is-number": {
-			"version": "7.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/xo/node_modules/locate-path": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
-			"integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^6.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
+				"node": ">=6"
 			}
 		},
 		"node_modules/xo/node_modules/meow": {
-			"version": "10.1.5",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
-			"integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
 			"dev": true,
-			"dependencies": {
-				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^7.0.0",
-				"decamelize": "^5.0.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.2",
-				"read-pkg-up": "^8.0.0",
-				"redent": "^4.0.0",
-				"trim-newlines": "^4.0.2",
-				"type-fest": "^1.2.2",
-				"yargs-parser": "^20.2.9"
-			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/merge2": {
-			"version": "1.4.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/xo/node_modules/micromatch": {
-			"version": "4.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
-		"node_modules/xo/node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/xo/node_modules/p-limit": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-			"dev": true,
-			"dependencies": {
-				"yocto-queue": "^1.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/p-locate": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/path-exists": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-			"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
 		"node_modules/xo/node_modules/path-type": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/picomatch": {
-			"version": "2.3.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/xo/node_modules/queue-microtask": {
-			"version": "1.2.3",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/xo/node_modules/quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/read-pkg": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
-			"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
-			"dev": true,
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.0",
-				"normalize-package-data": "^3.0.2",
-				"parse-json": "^5.2.0",
-				"type-fest": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/read-pkg-up": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-			"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
-			"dev": true,
-			"dependencies": {
-				"find-up": "^5.0.0",
-				"read-pkg": "^6.0.0",
-				"type-fest": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/read-pkg-up/node_modules/find-up": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
 			"dev": true,
-			"dependencies": {
-				"locate-path": "^6.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/read-pkg-up/node_modules/locate-path": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/read-pkg-up/node_modules/p-limit": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-			"dev": true,
-			"dependencies": {
-				"yocto-queue": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/read-pkg-up/node_modules/p-locate": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/read-pkg-up/node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/read-pkg-up/node_modules/yocto-queue": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/redent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-			"dev": true,
-			"dependencies": {
-				"indent-string": "^5.0.0",
-				"strip-indent": "^4.0.0"
-			},
 			"engines": {
 				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/regexpp": {
-			"version": "3.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
-		"node_modules/xo/node_modules/reusify": {
-			"version": "1.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/xo/node_modules/run-parallel": {
-			"version": "1.2.0",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
 			}
 		},
 		"node_modules/xo/node_modules/semver": {
-			"version": "7.3.5",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -18854,116 +19846,24 @@
 			}
 		},
 		"node_modules/xo/node_modules/slash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 			"dev": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/strip-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-			"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-			"dev": true,
-			"dependencies": {
-				"min-indent": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
-		},
-		"node_modules/xo/node_modules/trim-newlines": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
-			"integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+		"node_modules/xo/node_modules/unicorn-magic": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/tslib": {
-			"version": "1.14.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "0BSD"
-		},
-		"node_modules/xo/node_modules/tsutils": {
-			"version": "3.21.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-			}
-		},
-		"node_modules/xo/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-			"dev": true,
-			"inBundle": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/xo/node_modules/yallist": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/xo/node_modules/yocto-queue": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -19063,6 +19963,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
+			"integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -19629,26 +20541,51 @@
 			}
 		},
 		"@eslint-community/regexpp": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
-			"integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+			"integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
 			"dev": true
 		},
 		"@eslint/eslintrc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+			"integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
-				"globals": "^13.19.0",
+				"espree": "^10.0.1",
+				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
 				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+					"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+					"dev": true
+				},
+				"espree": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+					"integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+					"dev": true,
+					"requires": {
+						"acorn": "^8.12.0",
+						"acorn-jsx": "^5.3.2",
+						"eslint-visitor-keys": "^4.0.0"
+					}
+				},
+				"globals": {
+					"version": "14.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+					"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+					"dev": true
+				}
 			}
 		},
 		"@eslint/js": {
@@ -20276,24 +21213,24 @@
 			"dev": true
 		},
 		"@jridgewell/source-map": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+			"integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
 			},
 			"dependencies": {
 				"@jridgewell/gen-mapping": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-					"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+					"version": "0.3.5",
+					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+					"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 					"dev": true,
 					"requires": {
-						"@jridgewell/set-array": "^1.0.1",
+						"@jridgewell/set-array": "^1.2.1",
 						"@jridgewell/sourcemap-codec": "^1.4.10",
-						"@jridgewell/trace-mapping": "^0.3.9"
+						"@jridgewell/trace-mapping": "^0.3.24"
 					}
 				}
 			}
@@ -21184,6 +22121,12 @@
 				"nullthrows": "^1.1.1"
 			}
 		},
+		"@pkgr/core": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+			"integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+			"dev": true
+		},
 		"@pnpm/network.ca-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
@@ -21207,6 +22150,18 @@
 			"version": "2.11.6",
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
 			"integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+		},
+		"@rtsao/scc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+			"integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+			"dev": true
+		},
+		"@sec-ant/readable-stream": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+			"dev": true
 		},
 		"@sideway/address": {
 			"version": "4.1.5",
@@ -21239,6 +22194,12 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
 			"integrity": "sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==",
+			"dev": true
+		},
+		"@sindresorhus/merge-streams": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+			"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
 			"dev": true
 		},
 		"@sindresorhus/tsconfig": {
@@ -21409,30 +22370,19 @@
 			"dev": true
 		},
 		"@types/eslint": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
-			"integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+			"version": "8.56.12",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+			"integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
 			}
 		},
-		"@types/eslint-scope": {
-			"version": "3.7.4",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@types/eslint": "*",
-				"@types/estree": "*"
-			}
-		},
 		"@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true
 		},
 		"@types/filesystem": {
@@ -22007,74 +22957,80 @@
 				"eslint-visitor-keys": "^3.3.0"
 			}
 		},
+		"@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"dev": true
+		},
 		"@webassemblyjs/ast": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
+			"integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@webassemblyjs/helper-numbers": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+				"@webassemblyjs/helper-numbers": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+			"integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
 			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+			"integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
 			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
+			"integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
 			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-numbers": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+			"integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@webassemblyjs/floating-point-hex-parser": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+			"integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
 			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
+			"integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1"
+				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/helper-buffer": "1.12.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.12.1"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+			"integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -22082,9 +23038,9 @@
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+			"integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -22092,79 +23048,79 @@
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+			"integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
 			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
+			"integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/helper-wasm-section": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-opt": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
-				"@webassemblyjs/wast-printer": "1.11.1"
+				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/helper-buffer": "1.12.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/helper-wasm-section": "1.12.1",
+				"@webassemblyjs/wasm-gen": "1.12.1",
+				"@webassemblyjs/wasm-opt": "1.12.1",
+				"@webassemblyjs/wasm-parser": "1.12.1",
+				"@webassemblyjs/wast-printer": "1.12.1"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
+			"integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
+			"integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1"
+				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/helper-buffer": "1.12.1",
+				"@webassemblyjs/wasm-gen": "1.12.1",
+				"@webassemblyjs/wasm-parser": "1.12.1"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
+			"integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/helper-api-error": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
+			"integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/ast": "1.12.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
@@ -22204,9 +23160,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"dev": true
 		},
 		"acorn-globals": {
@@ -22219,10 +23175,10 @@
 				"acorn-walk": "^8.0.2"
 			}
 		},
-		"acorn-import-assertions": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+		"acorn-import-attributes": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {}
@@ -22486,28 +23442,33 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"array-buffer-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.5",
+				"is-array-buffer": "^3.0.4"
+			}
+		},
 		"array-differ": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
 			"integrity": "sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==",
 			"dev": true
 		},
-		"array-find": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
-			"integrity": "sha512-kO/vVCacW9mnpn3WPWbTVlEnOabK2L7LWi2HViURtCM46y1zb6I8UMjx4LgbiqadTgHnLInUronwn3ampNTJtQ==",
-			"dev": true
-		},
 		"array-includes": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
-			"integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+			"integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"get-intrinsic": "^1.1.3",
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
 				"is-string": "^1.0.7"
 			}
 		},
@@ -22517,41 +23478,85 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
+		"array.prototype.findlast": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+			"integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-shim-unscopables": "^1.0.2"
+			}
+		},
+		"array.prototype.findlastindex": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
+			"integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-shim-unscopables": "^1.0.2"
+			}
+		},
 		"array.prototype.flat": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+			"integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"es-shim-unscopables": "^1.0.0"
 			}
 		},
 		"array.prototype.flatmap": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
-			"integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+			"integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"es-shim-unscopables": "^1.0.0"
 			}
 		},
 		"array.prototype.tosorted": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
-			"integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+			"integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"es-shim-unscopables": "^1.0.0",
-				"get-intrinsic": "^1.1.3"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3",
+				"es-errors": "^1.3.0",
+				"es-shim-unscopables": "^1.0.2"
+			}
+		},
+		"arraybuffer.prototype.slice": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+			"integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+			"dev": true,
+			"requires": {
+				"array-buffer-byte-length": "^1.0.1",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.22.3",
+				"es-errors": "^1.2.1",
+				"get-intrinsic": "^1.2.3",
+				"is-array-buffer": "^3.0.4",
+				"is-shared-array-buffer": "^1.0.2"
 			}
 		},
 		"arrify": {
@@ -22613,10 +23618,13 @@
 			"dev": true
 		},
 		"available-typed-arrays": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-			"dev": true
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dev": true,
+			"requires": {
+				"possible-typed-array-names": "^1.0.0"
+			}
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -22800,24 +23808,24 @@
 			}
 		},
 		"braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"requires": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			}
 		},
 		"browserslist": {
-			"version": "4.21.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"version": "4.23.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+			"integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001400",
-				"electron-to-chromium": "^1.4.251",
-				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.9"
+				"caniuse-lite": "^1.0.30001646",
+				"electron-to-chromium": "^1.5.4",
+				"node-releases": "^2.0.18",
+				"update-browserslist-db": "^1.1.0"
 			}
 		},
 		"bs-logger": {
@@ -22872,6 +23880,15 @@
 			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
 			"dev": true
 		},
+		"bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"requires": {
+				"run-applescript": "^7.0.0"
+			}
+		},
 		"bunyan": {
 			"version": "1.8.15",
 			"resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
@@ -22912,13 +23929,16 @@
 			}
 		},
 		"call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
 			}
 		},
 		"callsites": {
@@ -23372,16 +24392,16 @@
 			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 			"dev": true
 		},
+		"common-path-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+			"integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+			"dev": true
+		},
 		"common-tags": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
 			"integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-			"dev": true
-		},
-		"commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
 			"dev": true
 		},
 		"concat-map": {
@@ -23492,6 +24512,15 @@
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.0.tgz",
 			"integrity": "sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==",
 			"dev": true
+		},
+		"core-js-compat": {
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
+			"integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.23.3"
+			}
 		},
 		"core-util-is": {
 			"version": "1.0.3",
@@ -23688,6 +24717,39 @@
 				"whatwg-url": "^11.0.0"
 			}
 		},
+		"data-view-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+			"integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			}
+		},
+		"data-view-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+			"integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			}
+		},
+		"data-view-byte-offset": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+			"integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			}
+		},
 		"debounce": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -23783,6 +24845,22 @@
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
 			"dev": true
 		},
+		"default-browser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+			"dev": true,
+			"requires": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			}
+		},
+		"default-browser-id": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+			"dev": true
+		},
 		"defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -23806,6 +24884,17 @@
 			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
 			"dev": true
 		},
+		"define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"requires": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			}
+		},
 		"define-lazy-prop": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -23813,11 +24902,12 @@
 			"dev": true
 		},
 		"define-properties": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
 			"dev": true,
 			"requires": {
+				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
@@ -23989,9 +25079,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.284",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+			"version": "1.5.26",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.26.tgz",
+			"integrity": "sha512-Z+OMe9M/V6Ep9n/52+b7lkvYEps26z4Yz3vjWL1V61W0q+VLF1pOHhMY17sa4roz4AWmULSI8E6SAojZA5L0YQ==",
 			"dev": true
 		},
 		"emittery": {
@@ -24046,6 +25136,12 @@
 			"integrity": "sha512-7AXskzN6T7Q9TFcKAGJprUbpQa4i1VsAetO9rdBqbGMGlragTziBgWt4pVYJMBWHQlLoX0buy6WFikzPH4Qjpw==",
 			"dev": true
 		},
+		"env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true
+		},
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -24056,71 +25152,130 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.21.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-			"integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+			"version": "1.23.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+			"integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
 			"dev": true,
 			"requires": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"es-set-tostringtag": "^2.0.1",
+				"array-buffer-byte-length": "^1.0.1",
+				"arraybuffer.prototype.slice": "^1.0.3",
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"data-view-buffer": "^1.0.1",
+				"data-view-byte-length": "^1.0.1",
+				"data-view-byte-offset": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-set-tostringtag": "^2.0.3",
 				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
-				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.3",
-				"get-symbol-description": "^1.0.0",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.4",
+				"get-symbol-description": "^1.0.2",
 				"globalthis": "^1.0.3",
 				"gopd": "^1.0.1",
-				"has": "^1.0.3",
-				"has-property-descriptors": "^1.0.0",
-				"has-proto": "^1.0.1",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
 				"has-symbols": "^1.0.3",
-				"internal-slot": "^1.0.4",
-				"is-array-buffer": "^3.0.1",
+				"hasown": "^2.0.2",
+				"internal-slot": "^1.0.7",
+				"is-array-buffer": "^3.0.4",
 				"is-callable": "^1.2.7",
-				"is-negative-zero": "^2.0.2",
+				"is-data-view": "^1.0.1",
+				"is-negative-zero": "^2.0.3",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.2",
+				"is-shared-array-buffer": "^1.0.3",
 				"is-string": "^1.0.7",
-				"is-typed-array": "^1.1.10",
+				"is-typed-array": "^1.1.13",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.2",
+				"object-inspect": "^1.13.1",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.4",
-				"regexp.prototype.flags": "^1.4.3",
-				"safe-regex-test": "^1.0.0",
-				"string.prototype.trimend": "^1.0.6",
-				"string.prototype.trimstart": "^1.0.6",
-				"typed-array-length": "^1.0.4",
+				"object.assign": "^4.1.5",
+				"regexp.prototype.flags": "^1.5.2",
+				"safe-array-concat": "^1.1.2",
+				"safe-regex-test": "^1.0.3",
+				"string.prototype.trim": "^1.2.9",
+				"string.prototype.trimend": "^1.0.8",
+				"string.prototype.trimstart": "^1.0.8",
+				"typed-array-buffer": "^1.0.2",
+				"typed-array-byte-length": "^1.0.1",
+				"typed-array-byte-offset": "^1.0.2",
+				"typed-array-length": "^1.0.6",
 				"unbox-primitive": "^1.0.2",
-				"which-typed-array": "^1.1.9"
+				"which-typed-array": "^1.1.15"
+			}
+		},
+		"es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.2.4"
+			}
+		},
+		"es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true
+		},
+		"es-iterator-helpers": {
+			"version": "1.0.19",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.19.tgz",
+			"integrity": "sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3",
+				"es-errors": "^1.3.0",
+				"es-set-tostringtag": "^2.0.3",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"globalthis": "^1.0.3",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.7",
+				"iterator.prototype": "^1.1.2",
+				"safe-array-concat": "^1.1.2"
 			}
 		},
 		"es-module-lexer": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+			"integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
 			"dev": true,
 			"peer": true
 		},
-		"es-set-tostringtag": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-			"integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+		"es-object-atoms": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
 			"dev": true,
 			"requires": {
-				"get-intrinsic": "^1.1.3",
-				"has": "^1.0.3",
-				"has-tostringtag": "^1.0.0"
+				"es-errors": "^1.3.0"
+			}
+		},
+		"es-set-tostringtag": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.2.4",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.1"
 			}
 		},
 		"es-shim-unscopables": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-			"integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.0"
 			}
 		},
 		"es-to-primitive": {
@@ -24147,9 +25302,9 @@
 			"dev": true
 		},
 		"escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true
 		},
 		"escape-goat": {
@@ -24324,10 +25479,27 @@
 				}
 			}
 		},
+		"eslint-compat-utils": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+			"integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+			"dev": true,
+			"requires": {
+				"semver": "^7.5.4"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.6.3",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+					"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+					"dev": true
+				}
+			}
+		},
 		"eslint-config-prettier": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
-			"integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+			"integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
 			"dev": true,
 			"requires": {}
 		},
@@ -24355,30 +25527,86 @@
 			"requires": {}
 		},
 		"eslint-formatter-pretty": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
-			"integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-6.0.1.tgz",
+			"integrity": "sha512-znAUcXmBthdIUmlnRkPSxz3zSJHFUhfHF/nJPcCMVKg/mOa4yUie2Olqg1Ghbi5JJRBZVU3rIgzWSObvIspxMA==",
 			"dev": true,
 			"requires": {
-				"@types/eslint": "^7.2.13",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.1.0",
-				"eslint-rule-docs": "^1.1.5",
-				"log-symbols": "^4.0.0",
-				"plur": "^4.0.0",
-				"string-width": "^4.2.0",
-				"supports-hyperlinks": "^2.0.0"
+				"@types/eslint": "^8.44.6",
+				"ansi-escapes": "^6.2.0",
+				"chalk": "^5.3.0",
+				"eslint-rule-docs": "^1.1.235",
+				"log-symbols": "^6.0.0",
+				"plur": "^5.1.0",
+				"string-width": "^7.0.0",
+				"supports-hyperlinks": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+					"integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+					"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+					"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "10.4.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+					"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+					"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^10.3.0",
+						"get-east-asian-width": "^1.0.0",
+						"strip-ansi": "^7.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+					"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^6.0.1"
+					}
+				},
+				"supports-hyperlinks": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.1.0.tgz",
+					"integrity": "sha512-2rn0BZ+/f7puLOHZm1HOJfwBggfaHXUpPUSSG/SWM4TWp5KCfmNYwnC3hruy2rZlMnmWZ+QAGpZfchu3f3695A==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0",
+						"supports-color": "^7.0.0"
+					}
+				}
 			}
 		},
 		"eslint-import-resolver-node": {
-			"version": "0.3.7",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
-			"integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+			"integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.2.7",
-				"is-core-module": "^2.11.0",
-				"resolve": "^1.22.1"
+				"is-core-module": "^2.13.0",
+				"resolve": "^1.22.4"
 			},
 			"dependencies": {
 				"debug": {
@@ -24393,22 +25621,21 @@
 			}
 		},
 		"eslint-import-resolver-webpack": {
-			"version": "0.13.2",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz",
-			"integrity": "sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==",
+			"version": "0.13.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.9.tgz",
+			"integrity": "sha512-yGngeefNiHXau2yzKKs2BNON4HLpxBabY40BGL/vUSKZtqzjlVsTTZm57jhHULhm+mJEwKsEIIN3NXup5AiiBQ==",
 			"dev": true,
 			"requires": {
-				"array-find": "^1.0.0",
 				"debug": "^3.2.7",
 				"enhanced-resolve": "^0.9.1",
 				"find-root": "^1.1.0",
-				"has": "^1.0.3",
+				"hasown": "^2.0.0",
 				"interpret": "^1.4.0",
-				"is-core-module": "^2.7.0",
+				"is-core-module": "^2.13.1",
 				"is-regex": "^1.1.4",
 				"lodash": "^4.17.21",
-				"resolve": "^1.20.0",
-				"semver": "^5.7.1"
+				"resolve": "^2.0.0-next.5",
+				"semver": "^5.7.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -24419,13 +25646,30 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				},
+				"resolve": {
+					"version": "2.0.0-next.5",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+					"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.13.0",
+						"path-parse": "^1.0.7",
+						"supports-preserve-symlinks-flag": "^1.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+					"dev": true
 				}
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
-			"integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.11.0.tgz",
+			"integrity": "sha512-gbBE5Hitek/oG6MUVj6sFuzEjA/ClzNflVrLovHi/JgLdC7fiN5gLAY1WIPW1a0V5I999MnsrvVrCOGmmVqDBQ==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.2.7"
@@ -24443,9 +25687,9 @@
 			}
 		},
 		"eslint-plugin-ava": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
-			"integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-14.0.0.tgz",
+			"integrity": "sha512-XmKT6hppaipwwnLVwwvQliSU6AF1QMHiNoLD5JQfzhUhf0jY7CO0O624fQrE+Y/fTb9vbW8r77nKf7M/oHulxw==",
 			"dev": true,
 			"requires": {
 				"enhance-visitors": "^1.0.0",
@@ -24475,31 +25719,15 @@
 				}
 			}
 		},
-		"eslint-plugin-es": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-			"integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+		"eslint-plugin-es-x": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+			"integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
 			"dev": true,
 			"requires": {
-				"eslint-utils": "^2.0.0",
-				"regexpp": "^3.0.0"
-			},
-			"dependencies": {
-				"eslint-utils": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-					"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-					"dev": true,
-					"requires": {
-						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-					"dev": true
-				}
+				"@eslint-community/eslint-utils": "^4.1.2",
+				"@eslint-community/regexpp": "^4.11.0",
+				"eslint-compat-utils": "^0.5.1"
 			}
 		},
 		"eslint-plugin-eslint-comments": {
@@ -24521,26 +25749,29 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.27.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
-			"integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
+			"integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.6",
-				"array.prototype.flat": "^1.3.1",
-				"array.prototype.flatmap": "^1.3.1",
+				"@rtsao/scc": "^1.1.0",
+				"array-includes": "^3.1.8",
+				"array.prototype.findlastindex": "^1.2.5",
+				"array.prototype.flat": "^1.3.2",
+				"array.prototype.flatmap": "^1.3.2",
 				"debug": "^3.2.7",
 				"doctrine": "^2.1.0",
-				"eslint-import-resolver-node": "^0.3.7",
-				"eslint-module-utils": "^2.7.4",
-				"has": "^1.0.3",
-				"is-core-module": "^2.11.0",
+				"eslint-import-resolver-node": "^0.3.9",
+				"eslint-module-utils": "^2.9.0",
+				"hasown": "^2.0.2",
+				"is-core-module": "^2.15.1",
 				"is-glob": "^4.0.3",
 				"minimatch": "^3.1.2",
-				"object.values": "^1.1.6",
-				"resolve": "^1.22.1",
-				"semver": "^6.3.0",
-				"tsconfig-paths": "^3.14.1"
+				"object.fromentries": "^2.0.8",
+				"object.groupby": "^1.0.3",
+				"object.values": "^1.2.0",
+				"semver": "^6.3.1",
+				"tsconfig-paths": "^3.15.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -24562,9 +25793,73 @@
 					}
 				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-n": {
+			"version": "17.10.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.10.3.tgz",
+			"integrity": "sha512-ySZBfKe49nQZWR1yFaA0v/GsH6Fgp8ah6XV0WDz6CN8WO0ek4McMzb7A2xnf4DCYV43frjCygvb9f/wx7UUxRw==",
+			"dev": true,
+			"requires": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"enhanced-resolve": "^5.17.0",
+				"eslint-plugin-es-x": "^7.5.0",
+				"get-tsconfig": "^4.7.0",
+				"globals": "^15.8.0",
+				"ignore": "^5.2.4",
+				"minimatch": "^9.0.5",
+				"semver": "^7.5.3"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"enhanced-resolve": {
+					"version": "5.17.1",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+					"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.4",
+						"tapable": "^2.2.0"
+					}
+				},
+				"globals": {
+					"version": "15.9.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
+					"integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "9.0.5",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+					"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				},
+				"semver": {
+					"version": "7.6.3",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+					"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+					"dev": true
+				},
+				"tapable": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+					"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 					"dev": true
 				}
 			}
@@ -24588,73 +25883,47 @@
 				"is-proto-prop": "^2.0.0"
 			}
 		},
-		"eslint-plugin-node": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-			"integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+		"eslint-plugin-prettier": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
+			"integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
 			"dev": true,
 			"requires": {
-				"eslint-plugin-es": "^3.0.0",
-				"eslint-utils": "^2.0.0",
-				"ignore": "^5.1.1",
-				"minimatch": "^3.0.4",
-				"resolve": "^1.10.1",
-				"semver": "^6.1.0"
-			},
-			"dependencies": {
-				"eslint-utils": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-					"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-					"dev": true,
-					"requires": {
-						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-					"dev": true
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
+				"prettier-linter-helpers": "^1.0.0",
+				"synckit": "^0.9.1"
 			}
 		},
-		"eslint-plugin-prettier": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-			"integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+		"eslint-plugin-promise": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
+			"integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
 			"dev": true,
-			"requires": {
-				"prettier-linter-helpers": "^1.0.0"
-			}
+			"requires": {}
 		},
 		"eslint-plugin-react": {
-			"version": "7.32.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
-			"integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
+			"version": "7.36.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.36.1.tgz",
+			"integrity": "sha512-/qwbqNXZoq+VP30s1d4Nc1C5GTxjJQjk4Jzs4Wq2qzxFM7dSmuG2UkIjg2USMLh3A/aVcUNrK7v0J5U1XEGGwA==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.6",
-				"array.prototype.flatmap": "^1.3.1",
-				"array.prototype.tosorted": "^1.1.1",
+				"array-includes": "^3.1.8",
+				"array.prototype.findlast": "^1.2.5",
+				"array.prototype.flatmap": "^1.3.2",
+				"array.prototype.tosorted": "^1.1.4",
 				"doctrine": "^2.1.0",
+				"es-iterator-helpers": "^1.0.19",
 				"estraverse": "^5.3.0",
+				"hasown": "^2.0.2",
 				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 				"minimatch": "^3.1.2",
-				"object.entries": "^1.1.6",
-				"object.fromentries": "^2.0.6",
-				"object.hasown": "^1.1.2",
-				"object.values": "^1.1.6",
+				"object.entries": "^1.1.8",
+				"object.fromentries": "^2.0.8",
+				"object.values": "^1.2.0",
 				"prop-types": "^15.8.1",
-				"resolve": "^2.0.0-next.4",
-				"semver": "^6.3.0",
-				"string.prototype.matchall": "^4.0.8"
+				"resolve": "^2.0.0-next.5",
+				"semver": "^6.3.1",
+				"string.prototype.matchall": "^4.0.11",
+				"string.prototype.repeat": "^1.0.0"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -24673,78 +25942,30 @@
 					"dev": true
 				},
 				"resolve": {
-					"version": "2.0.0-next.4",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
-					"integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+					"version": "2.0.0-next.5",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+					"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
 					"dev": true,
 					"requires": {
-						"is-core-module": "^2.9.0",
+						"is-core-module": "^2.13.0",
 						"path-parse": "^1.0.7",
 						"supports-preserve-symlinks-flag": "^1.0.0"
 					}
 				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-			"integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+			"integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
 			"dev": true,
 			"requires": {}
-		},
-		"eslint-plugin-unicorn": {
-			"version": "40.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-40.1.0.tgz",
-			"integrity": "sha512-y5doK2DF9Sr5AqKEHbHxjFllJ167nKDRU01HDcWyv4Tnmaoe9iNxMrBnaybZvWZUaE3OC5Unu0lNIevYamloig==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.15.7",
-				"ci-info": "^3.3.0",
-				"clean-regexp": "^1.0.0",
-				"eslint-utils": "^3.0.0",
-				"esquery": "^1.4.0",
-				"indent-string": "^4.0.0",
-				"is-builtin-module": "^3.1.0",
-				"lodash": "^4.17.21",
-				"pluralize": "^8.0.0",
-				"read-pkg-up": "^7.0.1",
-				"regexp-tree": "^0.1.24",
-				"safe-regex": "^2.1.1",
-				"semver": "^7.3.5",
-				"strip-indent": "^3.0.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
-				}
-			}
 		},
 		"eslint-rule-docs": {
 			"version": "1.1.235",
@@ -24786,10 +26007,14 @@
 			"dev": true
 		},
 		"esm-utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-2.2.0.tgz",
-			"integrity": "sha512-kYj4yNRo4W3by0f1mj4AfRh1nsRTTpQG921Ik3AfyUq6upGlkI1fnMLypHn6XtFzZPdCYH1k9mtQA5MyZF9m+w==",
-			"dev": true
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-4.3.0.tgz",
+			"integrity": "sha512-KupZztbWAnuksy1TYPjTkePxVlMWzmXdmB72z1WvUadtUiFv6x+0PKjYfyy1io9gdvU1A6QIcu055NRrJu1TEA==",
+			"dev": true,
+			"requires": {
+				"import-meta-resolve": "^4.1.0",
+				"url-or-path": "^2.3.0"
+			}
 		},
 		"espree": {
 			"version": "9.5.0",
@@ -24997,15 +26222,15 @@
 			"dev": true
 		},
 		"fast-diff": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.2.12",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -25110,6 +26335,23 @@
 				"web-streams-polyfill": "^3.0.3"
 			}
 		},
+		"figures": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+			"integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+			"dev": true,
+			"requires": {
+				"is-unicode-supported": "^2.0.0"
+			},
+			"dependencies": {
+				"is-unicode-supported": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+					"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+					"dev": true
+				}
+			}
+		},
 		"file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -25120,23 +26362,82 @@
 			}
 		},
 		"fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
 			}
 		},
 		"find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-5.0.0.tgz",
+			"integrity": "sha512-OuWNfjfP05JcpAP3JPgAKUhWefjMRfI5iAoSsvE24ANYWJaepAtlSgWECSVEuRgSXpyNEc9DJwG/TZpgcOqyig==",
 			"dev": true,
 			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
+				"common-path-prefix": "^3.0.0",
+				"pkg-dir": "^7.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+					"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^7.1.0",
+						"path-exists": "^5.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+					"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^6.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+					"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+					"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^4.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+					"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+					"integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^6.3.0"
+					}
+				},
+				"yocto-queue": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+					"integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+					"dev": true
+				}
 			}
 		},
 		"find-file-up": {
@@ -25192,6 +26493,12 @@
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
 			}
+		},
+		"find-up-simple": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+			"integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+			"dev": true
 		},
 		"firefox-profile": {
 			"version": "4.2.2",
@@ -25345,21 +26652,21 @@
 			"optional": true
 		},
 		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"dev": true
 		},
 		"function.prototype.name": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.0",
-				"functions-have-names": "^1.2.2"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
 			}
 		},
 		"functions-have-names": {
@@ -25447,15 +26754,23 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
-		"get-intrinsic": {
+		"get-east-asian-width": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-			"integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+			"integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.3"
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
 			}
 		},
 		"get-package-type": {
@@ -25489,13 +26804,23 @@
 			"dev": true
 		},
 		"get-symbol-description": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+			"integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.1"
+				"call-bind": "^1.0.5",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4"
+			}
+		},
+		"get-tsconfig": {
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
+			"integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+			"dev": true,
+			"requires": {
+				"resolve-pkg-maps": "^1.0.0"
 			}
 		},
 		"getpass": {
@@ -25657,6 +26982,12 @@
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
 		},
+		"graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
+		},
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -25685,15 +27016,6 @@
 			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
 			"dev": true
 		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
 		"has-bigints": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -25707,18 +27029,18 @@
 			"dev": true
 		},
 		"has-property-descriptors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"dev": true,
 			"requires": {
-				"get-intrinsic": "^1.1.1"
+				"es-define-property": "^1.0.0"
 			}
 		},
 		"has-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
 			"dev": true
 		},
 		"has-symbols": {
@@ -25728,12 +27050,12 @@
 			"dev": true
 		},
 		"has-tostringtag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
 			"dev": true,
 			"requires": {
-				"has-symbols": "^1.0.2"
+				"has-symbols": "^1.0.3"
 			}
 		},
 		"has-yarn": {
@@ -25741,6 +27063,15 @@
 			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-3.0.0.tgz",
 			"integrity": "sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==",
 			"dev": true
+		},
+		"hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.2"
+			}
 		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
@@ -25879,9 +27210,9 @@
 			"dev": true
 		},
 		"ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true
 		},
 		"image-size": {
@@ -25925,6 +27256,12 @@
 				"resolve-cwd": "^3.0.0"
 			}
 		},
+		"import-meta-resolve": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+			"integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+			"dev": true
+		},
 		"import-modules": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
@@ -25966,13 +27303,13 @@
 			"dev": true
 		},
 		"internal-slot": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
-			"integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
 			"dev": true,
 			"requires": {
-				"get-intrinsic": "^1.1.3",
-				"has": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"hasown": "^2.0.0",
 				"side-channel": "^1.0.4"
 			}
 		},
@@ -25994,9 +27331,9 @@
 			"dev": true
 		},
 		"irregular-plurals": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.4.0.tgz",
-			"integrity": "sha512-YXxECO/W6N9aMBVKMKKZ8TXESgq7EFrp3emCGGUcrYY1cgJIeZjoB75MTu8qi+NAKntS9NwPU8VdcQ3r6E6aWQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+			"integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
 			"dev": true
 		},
 		"is-absolute": {
@@ -26010,14 +27347,13 @@
 			}
 		},
 		"is-array-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-			"integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.3",
-				"is-typed-array": "^1.1.10"
+				"get-intrinsic": "^1.2.1"
 			}
 		},
 		"is-arrayish": {
@@ -26025,6 +27361,15 @@
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true
+		},
+		"is-async-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+			"integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
 		},
 		"is-bigint": {
 			"version": "1.0.4",
@@ -26046,9 +27391,9 @@
 			}
 		},
 		"is-builtin-module": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
-			"integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+			"integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
 			"dev": true,
 			"requires": {
 				"builtin-modules": "^3.3.0"
@@ -26070,12 +27415,21 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+			"integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.2"
+			}
+		},
+		"is-data-view": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+			"integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+			"dev": true,
+			"requires": {
+				"is-typed-array": "^1.1.13"
 			}
 		},
 		"is-date-object": {
@@ -26099,6 +27453,15 @@
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
 			"dev": true
 		},
+		"is-finalizationregistry": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+			"integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2"
+			}
+		},
 		"is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -26110,6 +27473,15 @@
 			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
 			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 			"dev": true
+		},
+		"is-generator-function": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
 		},
 		"is-get-set-prop": {
 			"version": "1.0.0",
@@ -26138,6 +27510,23 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"requires": {
+				"is-docker": "^3.0.0"
+			},
+			"dependencies": {
+				"is-docker": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+					"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+					"dev": true
+				}
+			}
+		},
 		"is-installed-globally": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
@@ -26163,6 +27552,12 @@
 			"integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
 			"dev": true
 		},
+		"is-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+			"integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+			"dev": true
+		},
 		"is-mergeable-object": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.1.tgz",
@@ -26176,9 +27571,9 @@
 			"dev": true
 		},
 		"is-negative-zero": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
 			"dev": true
 		},
 		"is-npm": {
@@ -26287,13 +27682,19 @@
 				"is-unc-path": "^1.0.0"
 			}
 		},
+		"is-set": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+			"integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+			"dev": true
+		},
 		"is-shared-array-buffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2"
+				"call-bind": "^1.0.7"
 			}
 		},
 		"is-stream": {
@@ -26321,16 +27722,12 @@
 			}
 		},
 		"is-typed-array": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-			"integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
 			"dev": true,
 			"requires": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0"
+				"which-typed-array": "^1.1.14"
 			}
 		},
 		"is-typedarray": {
@@ -26349,15 +27746,21 @@
 			}
 		},
 		"is-unicode-supported": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
 			"dev": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
+			"dev": true
+		},
+		"is-weakmap": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+			"integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
 			"dev": true
 		},
 		"is-weakref": {
@@ -26367,6 +27770,16 @@
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2"
+			}
+		},
+		"is-weakset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
+			"integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4"
 			}
 		},
 		"is-windows": {
@@ -26388,6 +27801,12 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.4.1.tgz",
 			"integrity": "sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==",
+			"dev": true
+		},
+		"isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
 			"dev": true
 		},
 		"isexe": {
@@ -26459,6 +27878,19 @@
 			"requires": {
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
+			}
+		},
+		"iterator.prototype": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
+			"integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.2.1",
+				"get-intrinsic": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"reflect.getprototypeof": "^1.0.4",
+				"set-function-name": "^2.0.1"
 			}
 		},
 		"jed": {
@@ -28076,13 +29508,21 @@
 			"dev": true
 		},
 		"log-symbols": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+			"integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^4.1.0",
-				"is-unicode-supported": "^0.1.0"
+				"chalk": "^5.3.0",
+				"is-unicode-supported": "^1.3.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+					"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+					"dev": true
+				}
 			}
 		},
 		"loose-envify": {
@@ -28288,12 +29728,12 @@
 			"dev": true
 		},
 		"micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"requires": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			}
 		},
@@ -28661,9 +30101,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-			"integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
 			"dev": true
 		},
 		"normalize-package-data": {
@@ -28847,9 +30287,9 @@
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
 		},
 		"object-inspect": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
 			"dev": true
 		},
 		"object-keys": {
@@ -28859,58 +30299,60 @@
 			"dev": true
 		},
 		"object.assign": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
 				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
 			}
 		},
 		"object.entries": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
-			"integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
+			"integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
 			}
 		},
 		"object.fromentries": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
-			"integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+			"integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-object-atoms": "^1.0.0"
 			}
 		},
-		"object.hasown": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
-			"integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+		"object.groupby": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+			"integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2"
 			}
 		},
 		"object.values": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
-			"integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
+			"integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
 			}
 		},
 		"on-exit-leak-free": {
@@ -28949,21 +30391,126 @@
 			}
 		},
 		"open-editor": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/open-editor/-/open-editor-4.0.0.tgz",
-			"integrity": "sha512-5mKZ98iFdkivozt5XTCOspoKbL3wtYu6oOoVxfWQ0qUX9NYsK8pdkHE7VUHXr+CwyC3nf6mV0S5FPsMS65innw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/open-editor/-/open-editor-5.0.0.tgz",
+			"integrity": "sha512-fRHi4my03WQSbWfqChs9AdFfSp6SLalB3zadfwfYIojoKanLDBfv2uAdiZCfzdvom7TBdlXu2UeiiydBc56/EQ==",
 			"dev": true,
 			"requires": {
-				"env-editor": "^1.0.0",
-				"execa": "^5.1.1",
+				"env-editor": "^1.1.0",
+				"execa": "^9.3.0",
 				"line-column-path": "^3.0.0",
-				"open": "^8.4.0"
+				"open": "^10.1.0"
+			},
+			"dependencies": {
+				"define-lazy-prop": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+					"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+					"dev": true
+				},
+				"execa": {
+					"version": "9.4.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-9.4.0.tgz",
+					"integrity": "sha512-yKHlle2YGxZE842MERVIplWwNH5VYmqqcPFgtnlU//K8gxuFFXu0pwd/CrfXTumFpeEiufsP7+opT/bPJa1yVw==",
+					"dev": true,
+					"requires": {
+						"@sindresorhus/merge-streams": "^4.0.0",
+						"cross-spawn": "^7.0.3",
+						"figures": "^6.1.0",
+						"get-stream": "^9.0.0",
+						"human-signals": "^8.0.0",
+						"is-plain-obj": "^4.1.0",
+						"is-stream": "^4.0.1",
+						"npm-run-path": "^6.0.0",
+						"pretty-ms": "^9.0.0",
+						"signal-exit": "^4.1.0",
+						"strip-final-newline": "^4.0.0",
+						"yoctocolors": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+					"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+					"dev": true,
+					"requires": {
+						"@sec-ant/readable-stream": "^0.4.1",
+						"is-stream": "^4.0.1"
+					}
+				},
+				"human-signals": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
+					"integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
+					"dev": true
+				},
+				"is-plain-obj": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+					"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+					"dev": true
+				},
+				"is-stream": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+					"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+					"dev": true
+				},
+				"is-wsl": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+					"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+					"dev": true,
+					"requires": {
+						"is-inside-container": "^1.0.0"
+					}
+				},
+				"npm-run-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+					"integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+					"dev": true,
+					"requires": {
+						"path-key": "^4.0.0",
+						"unicorn-magic": "^0.3.0"
+					}
+				},
+				"open": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+					"integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+					"dev": true,
+					"requires": {
+						"default-browser": "^5.2.1",
+						"define-lazy-prop": "^3.0.0",
+						"is-inside-container": "^1.0.0",
+						"is-wsl": "^3.1.0"
+					}
+				},
+				"path-key": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+					"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				},
+				"strip-final-newline": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+					"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+					"dev": true
+				}
 			}
 		},
 		"optionator": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
 			"requires": {
 				"deep-is": "^0.1.3",
@@ -28971,7 +30518,7 @@
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
 				"type-check": "^0.4.0",
-				"word-wrap": "^1.2.3"
+				"word-wrap": "^1.2.5"
 			}
 		},
 		"ordered-binary": {
@@ -29172,6 +30719,12 @@
 				"lines-and-columns": "^1.1.6"
 			}
 		},
+		"parse-ms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+			"integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+			"dev": true
+		},
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -29301,9 +30854,9 @@
 			"dev": true
 		},
 		"picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+			"integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
 			"dev": true
 		},
 		"picomatch": {
@@ -29438,18 +30991,24 @@
 			}
 		},
 		"plur": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
-			"integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-5.1.0.tgz",
+			"integrity": "sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==",
 			"dev": true,
 			"requires": {
-				"irregular-plurals": "^3.2.0"
+				"irregular-plurals": "^3.3.0"
 			}
 		},
 		"pluralize": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
 			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"dev": true
+		},
+		"possible-typed-array-names": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
 			"dev": true
 		},
 		"postcss": {
@@ -29544,9 +31103,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-			"integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+			"integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -29575,6 +31134,15 @@
 					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 					"dev": true
 				}
+			}
+		},
+		"pretty-ms": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.1.0.tgz",
+			"integrity": "sha512-o1piW0n3tgKIKCwk2vpM/vOV13zjJzvP37Ioze54YlTHE06m4tjEbzg9WsKkvTuyYln2DHjo5pY4qrZGI0otpw==",
+			"dev": true,
+			"requires": {
+				"parse-ms": "^4.0.0"
 			}
 		},
 		"process": {
@@ -29984,6 +31552,21 @@
 				"strip-indent": "^3.0.0"
 			}
 		},
+		"reflect.getprototypeof": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
+			"integrity": "sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.1",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"globalthis": "^1.0.3",
+				"which-builtin-type": "^1.1.3"
+			}
+		},
 		"regenerator-runtime": {
 			"version": "0.13.11",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -29991,20 +31574,21 @@
 			"dev": true
 		},
 		"regexp-tree": {
-			"version": "0.1.24",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
-			"integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+			"integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
 			"dev": true
 		},
 		"regexp.prototype.flags": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-			"integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+			"integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"functions-have-names": "^1.2.2"
+				"call-bind": "^1.0.6",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"set-function-name": "^2.0.1"
 			}
 		},
 		"regexpp": {
@@ -30029,6 +31613,23 @@
 			"dev": true,
 			"requires": {
 				"rc": "1.2.8"
+			}
+		},
+		"regjsparser": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.10.0.tgz",
+			"integrity": "sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==",
+			"dev": true,
+			"requires": {
+				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+					"dev": true
+				}
 			}
 		},
 		"relaxed-json": {
@@ -30180,12 +31781,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.9.0",
+				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
@@ -30259,6 +31860,12 @@
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
 		},
+		"resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true
+		},
 		"resolve.exports": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.0.tgz",
@@ -30289,6 +31896,12 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"run-applescript": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+			"integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+			"dev": true
+		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -30307,6 +31920,18 @@
 				"tslib": "^2.1.0"
 			}
 		},
+		"safe-array-concat": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+			"integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4",
+				"has-symbols": "^1.0.3",
+				"isarray": "^2.0.5"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -30320,23 +31945,14 @@
 			"dev": true,
 			"optional": true
 		},
-		"safe-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
-			"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
-			"dev": true,
-			"requires": {
-				"regexp-tree": "~0.1.1"
-			}
-		},
 		"safe-regex-test": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+			"integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.3",
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
 				"is-regex": "^1.1.4"
 			}
 		},
@@ -30376,9 +31992,9 @@
 			}
 		},
 		"schema-utils": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -30429,9 +32045,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-			"integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -30469,6 +32085,32 @@
 						"mime-db": "~1.33.0"
 					}
 				}
+			}
+		},
+		"set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"requires": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			}
+		},
+		"set-function-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"dev": true,
+			"requires": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
 			}
 		},
 		"setimmediate": {
@@ -30515,14 +32157,15 @@
 			"dev": true
 		},
 		"side-channel": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0",
-				"get-intrinsic": "^1.0.2",
-				"object-inspect": "^1.9.0"
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
 			}
 		},
 		"sign-addon": {
@@ -30801,19 +32444,23 @@
 			}
 		},
 		"string.prototype.matchall": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
-			"integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
+			"integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"get-intrinsic": "^1.1.3",
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
 				"has-symbols": "^1.0.3",
-				"internal-slot": "^1.0.3",
-				"regexp.prototype.flags": "^1.4.3",
-				"side-channel": "^1.0.4"
+				"internal-slot": "^1.0.7",
+				"regexp.prototype.flags": "^1.5.2",
+				"set-function-name": "^2.0.2",
+				"side-channel": "^1.0.6"
 			}
 		},
 		"string.prototype.padend": {
@@ -30827,26 +32474,48 @@
 				"es-abstract": "^1.20.4"
 			}
 		},
-		"string.prototype.trimend": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-			"integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+		"string.prototype.repeat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+			"integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			}
+		},
+		"string.prototype.trim": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+			"integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.0",
+				"es-object-atoms": "^1.0.0"
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+			"integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-			"integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+			"integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
 			}
 		},
 		"strip-ansi": {
@@ -31045,6 +32714,16 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
+		"synckit": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
+			"integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
+			"dev": true,
+			"requires": {
+				"@pkgr/core": "^0.1.0",
+				"tslib": "^2.6.2"
+			}
+		},
 		"table": {
 			"version": "6.8.1",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -31116,13 +32795,13 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "5.16.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-			"integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.33.0.tgz",
+			"integrity": "sha512-JuPVaB7s1gdFKPKTelwUyRq5Sid2A3Gko2S0PncwdBq7kN9Ti9HPWDQ06MPsEDGsZeVESjKEnyGy68quBk1w6g==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/source-map": "^0.3.2",
-				"acorn": "^8.5.0",
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			},
@@ -31136,17 +32815,17 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "5.3.6",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
-			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+			"version": "5.3.10",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+			"integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.14",
+				"@jridgewell/trace-mapping": "^0.3.20",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.0",
-				"terser": "^5.14.1"
+				"serialize-javascript": "^6.0.1",
+				"terser": "^5.26.0"
 			}
 		},
 		"test-exclude": {
@@ -31229,9 +32908,9 @@
 			"dev": true
 		},
 		"to-absolute-glob": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha512-rtwLUQEwT8ZeKQbyFJyomBRYXyE16U5VKuy0ftxLMK/PZb2fkOsg5r9kHdauuVDbsNdIBoC/HCthpidamQFXYA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-3.0.0.tgz",
+			"integrity": "sha512-loO/XEWTRqpfcpI7+Jr2RR2Umaaozx1t6OSVWtMi0oy5F/Fxg3IC+D/TToDnxyAGs7uZBGT/6XmyDUxgsObJXA==",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -31299,6 +32978,13 @@
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
 			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
 			"dev": true
+		},
+		"ts-api-utils": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+			"dev": true,
+			"requires": {}
 		},
 		"ts-jest": {
 			"version": "29.0.5",
@@ -31382,13 +33068,13 @@
 			}
 		},
 		"tsconfig-paths": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-			"integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+			"integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
 			"dev": true,
 			"requires": {
 				"@types/json5": "^0.0.29",
-				"json5": "^1.0.1",
+				"json5": "^1.0.2",
 				"minimist": "^1.2.6",
 				"strip-bom": "^3.0.0"
 			},
@@ -31411,9 +33097,9 @@
 			}
 		},
 		"tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
 		},
 		"tsutils": {
 			"version": "3.21.0",
@@ -31468,15 +33154,56 @@
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
-		"typed-array-length": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
-			"integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+		"typed-array-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"typed-array-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+			"integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
 				"for-each": "^0.3.3",
-				"is-typed-array": "^1.1.9"
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"typed-array-byte-offset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+			"integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+			"dev": true,
+			"requires": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"typed-array-length": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+			"integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13",
+				"possible-typed-array-names": "^1.0.0"
 			}
 		},
 		"typedarray": {
@@ -31528,6 +33255,12 @@
 			"integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
 			"dev": true
 		},
+		"unicorn-magic": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true
+		},
 		"unique-string": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
@@ -31544,13 +33277,13 @@
 			"dev": true
 		},
 		"update-browserslist-db": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+			"integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
 			"dev": true,
 			"requires": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.1.2",
+				"picocolors": "^1.0.1"
 			}
 		},
 		"update-notifier": {
@@ -31615,6 +33348,12 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"url-or-path": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/url-or-path/-/url-or-path-2.3.0.tgz",
+			"integrity": "sha512-5g9xpEJKjbAY8ikLU3XFpEg3hRLGt6SbCQmDElb1AL7JTW6vMi5Na5e3dMvONHisIu9VHgMAADLHJ8EznYR2ow==",
+			"dev": true
 		},
 		"url-parse": {
 			"version": "1.5.10",
@@ -31900,49 +33639,41 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "5.76.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
-			"integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
+			"version": "5.94.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+			"integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@types/eslint-scope": "^3.7.3",
-				"@types/estree": "^0.0.51",
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/wasm-edit": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
+				"@types/estree": "^1.0.5",
+				"@webassemblyjs/ast": "^1.12.1",
+				"@webassemblyjs/wasm-edit": "^1.12.1",
+				"@webassemblyjs/wasm-parser": "^1.12.1",
 				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.7.6",
-				"browserslist": "^4.14.5",
+				"acorn-import-attributes": "^1.9.5",
+				"browserslist": "^4.21.10",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.10.0",
-				"es-module-lexer": "^0.9.0",
+				"enhanced-resolve": "^5.17.1",
+				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
-				"graceful-fs": "^4.2.9",
+				"graceful-fs": "^4.2.11",
 				"json-parse-even-better-errors": "^2.3.1",
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.1.0",
+				"schema-utils": "^3.2.0",
 				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.1.3",
-				"watchpack": "^2.4.0",
+				"terser-webpack-plugin": "^5.3.10",
+				"watchpack": "^2.4.1",
 				"webpack-sources": "^3.2.3"
 			},
 			"dependencies": {
-				"@types/estree": {
-					"version": "0.0.51",
-					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-					"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-					"dev": true,
-					"peer": true
-				},
 				"enhanced-resolve": {
-					"version": "5.12.0",
-					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
-					"integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+					"version": "5.17.1",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+					"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -31950,12 +33681,30 @@
 						"tapable": "^2.2.0"
 					}
 				},
+				"graceful-fs": {
+					"version": "4.2.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+					"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+					"dev": true,
+					"peer": true
+				},
 				"tapable": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
 					"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 					"dev": true,
 					"peer": true
+				},
+				"watchpack": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+					"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"glob-to-regexp": "^0.4.1",
+						"graceful-fs": "^4.1.2"
+					}
 				}
 			}
 		},
@@ -32019,18 +33768,49 @@
 				"is-symbol": "^1.0.3"
 			}
 		},
-		"which-typed-array": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-			"integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+		"which-builtin-type": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.4.tgz",
+			"integrity": "sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==",
 			"dev": true,
 			"requires": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
+				"function.prototype.name": "^1.1.6",
+				"has-tostringtag": "^1.0.2",
+				"is-async-function": "^2.0.0",
+				"is-date-object": "^1.0.5",
+				"is-finalizationregistry": "^1.0.2",
+				"is-generator-function": "^1.0.10",
+				"is-regex": "^1.1.4",
+				"is-weakref": "^1.0.2",
+				"isarray": "^2.0.5",
+				"which-boxed-primitive": "^1.0.2",
+				"which-collection": "^1.0.2",
+				"which-typed-array": "^1.1.15"
+			}
+		},
+		"which-collection": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+			"integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+			"dev": true,
+			"requires": {
+				"is-map": "^2.0.3",
+				"is-set": "^2.0.3",
+				"is-weakmap": "^2.0.2",
+				"is-weakset": "^2.0.3"
+			}
+		},
+		"which-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+			"integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+			"dev": true,
+			"requires": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
 				"for-each": "^0.3.3",
 				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0",
-				"is-typed-array": "^1.1.10"
+				"has-tostringtag": "^1.0.2"
 			}
 		},
 		"widest-line": {
@@ -32083,9 +33863,9 @@
 			"dev": true
 		},
 		"word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true
 		},
 		"wrap-ansi": {
@@ -32199,152 +33979,157 @@
 			"dev": true
 		},
 		"xo": {
-			"version": "0.48.0",
-			"resolved": "https://registry.npmjs.org/xo/-/xo-0.48.0.tgz",
-			"integrity": "sha512-f0sbQGJoML3nwOLG7EIAJroBypmLokoGJqTPN+bI/oogKLMciqWBEiFh9Vpxnfwxafq1AkHoWrQZQWSflDCG1w==",
+			"version": "0.59.3",
+			"resolved": "https://registry.npmjs.org/xo/-/xo-0.59.3.tgz",
+			"integrity": "sha512-jjUplAF4kqNP22HIlgnW+Ej8/Z1utf4Mzw/dLsbOcSpnUgrEqcyaS/OhGFriFyEBbnWVkslnYgUHiDsb6lNiBQ==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.0.5",
-				"@typescript-eslint/eslint-plugin": "*",
-				"@typescript-eslint/parser": "*",
+				"@eslint/eslintrc": "^3.1.0",
+				"@typescript-eslint/eslint-plugin": "^7.16.1",
+				"@typescript-eslint/parser": "^7.16.1",
 				"arrify": "^3.0.0",
-				"cosmiconfig": "^7.0.1",
+				"cosmiconfig": "^9.0.0",
 				"define-lazy-prop": "^3.0.0",
-				"eslint": "^8.8.0",
-				"eslint-config-prettier": "^8.3.0",
-				"eslint-config-xo": "^0.40.0",
-				"eslint-config-xo-typescript": "*",
-				"eslint-formatter-pretty": "^4.1.0",
-				"eslint-import-resolver-webpack": "^0.13.2",
-				"eslint-plugin-ava": "^13.2.0",
+				"eslint": "^8.57.0",
+				"eslint-config-prettier": "^9.1.0",
+				"eslint-config-xo": "^0.45.0",
+				"eslint-config-xo-typescript": "^5.0.0",
+				"eslint-formatter-pretty": "^6.0.1",
+				"eslint-import-resolver-webpack": "^0.13.8",
+				"eslint-plugin-ava": "^14.0.0",
 				"eslint-plugin-eslint-comments": "^3.2.0",
-				"eslint-plugin-import": "^2.25.4",
+				"eslint-plugin-import": "^2.29.1",
+				"eslint-plugin-n": "^17.9.0",
 				"eslint-plugin-no-use-extend-native": "^0.5.0",
-				"eslint-plugin-node": "^11.1.0",
-				"eslint-plugin-prettier": "^4.0.0",
-				"eslint-plugin-unicorn": "^40.1.0",
-				"esm-utils": "^2.0.1",
-				"find-cache-dir": "^3.3.2",
-				"find-up": "^6.3.0",
+				"eslint-plugin-prettier": "^5.2.1",
+				"eslint-plugin-promise": "^6.4.0",
+				"eslint-plugin-unicorn": "^54.0.0",
+				"esm-utils": "^4.3.0",
+				"find-cache-dir": "^5.0.0",
+				"find-up-simple": "^1.0.0",
 				"get-stdin": "^9.0.0",
-				"globby": "^13.1.1",
+				"get-tsconfig": "^4.7.5",
+				"globby": "^14.0.2",
 				"imurmurhash": "^0.1.4",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"json5": "^2.2.0",
 				"lodash-es": "^4.17.21",
-				"meow": "^10.1.2",
-				"micromatch": "^4.0.4",
-				"open-editor": "^4.0.0",
-				"prettier": "^2.5.1",
-				"semver": "^7.3.5",
-				"slash": "^4.0.0",
-				"to-absolute-glob": "^2.0.2",
-				"typescript": "^4.5.5"
+				"meow": "^13.2.0",
+				"micromatch": "^4.0.7",
+				"open-editor": "^5.0.0",
+				"prettier": "^3.3.3",
+				"semver": "^7.6.3",
+				"slash": "^5.1.0",
+				"to-absolute-glob": "^3.0.0",
+				"typescript": "^5.5.3"
 			},
 			"dependencies": {
-				"@nodelib/fs.scandir": {
-					"version": "2.1.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "2.0.5",
-						"run-parallel": "^1.1.9"
-					}
-				},
-				"@nodelib/fs.stat": {
-					"version": "2.0.5",
-					"bundled": true,
+				"@eslint/js": {
+					"version": "8.57.1",
+					"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+					"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
 					"dev": true
 				},
-				"@nodelib/fs.walk": {
-					"version": "1.2.8",
-					"bundled": true,
+				"@humanwhocodes/config-array": {
+					"version": "0.13.0",
+					"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+					"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
 					"dev": true,
 					"requires": {
-						"@nodelib/fs.scandir": "2.1.5",
-						"fastq": "^1.6.0"
+						"@humanwhocodes/object-schema": "^2.0.3",
+						"debug": "^4.3.1",
+						"minimatch": "^3.0.5"
 					}
 				},
-				"@types/json-schema": {
-					"version": "7.0.9",
-					"bundled": true,
+				"@humanwhocodes/object-schema": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+					"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+					"dev": true
+				},
+				"@sindresorhus/merge-streams": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+					"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
 					"dev": true
 				},
 				"@typescript-eslint/eslint-plugin": {
-					"version": "5.11.0",
-					"bundled": true,
+					"version": "7.18.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+					"integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/scope-manager": "5.11.0",
-						"@typescript-eslint/type-utils": "5.11.0",
-						"@typescript-eslint/utils": "5.11.0",
-						"debug": "^4.3.2",
-						"functional-red-black-tree": "^1.0.1",
-						"ignore": "^5.1.8",
-						"regexpp": "^3.2.0",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
-					},
-					"dependencies": {
-						"ignore": {
-							"version": "5.2.0",
-							"bundled": true,
-							"dev": true
-						}
+						"@eslint-community/regexpp": "^4.10.0",
+						"@typescript-eslint/scope-manager": "7.18.0",
+						"@typescript-eslint/type-utils": "7.18.0",
+						"@typescript-eslint/utils": "7.18.0",
+						"@typescript-eslint/visitor-keys": "7.18.0",
+						"graphemer": "^1.4.0",
+						"ignore": "^5.3.1",
+						"natural-compare": "^1.4.0",
+						"ts-api-utils": "^1.3.0"
 					}
 				},
 				"@typescript-eslint/parser": {
-					"version": "5.11.0",
-					"bundled": true,
+					"version": "7.18.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+					"integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/scope-manager": "5.11.0",
-						"@typescript-eslint/types": "5.11.0",
-						"@typescript-eslint/typescript-estree": "5.11.0",
-						"debug": "^4.3.2"
+						"@typescript-eslint/scope-manager": "7.18.0",
+						"@typescript-eslint/types": "7.18.0",
+						"@typescript-eslint/typescript-estree": "7.18.0",
+						"@typescript-eslint/visitor-keys": "7.18.0",
+						"debug": "^4.3.4"
 					}
 				},
 				"@typescript-eslint/scope-manager": {
-					"version": "5.11.0",
-					"bundled": true,
+					"version": "7.18.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+					"integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "5.11.0",
-						"@typescript-eslint/visitor-keys": "5.11.0"
+						"@typescript-eslint/types": "7.18.0",
+						"@typescript-eslint/visitor-keys": "7.18.0"
 					}
 				},
 				"@typescript-eslint/type-utils": {
-					"version": "5.11.0",
-					"bundled": true,
+					"version": "7.18.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+					"integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/utils": "5.11.0",
-						"debug": "^4.3.2",
-						"tsutils": "^3.21.0"
+						"@typescript-eslint/typescript-estree": "7.18.0",
+						"@typescript-eslint/utils": "7.18.0",
+						"debug": "^4.3.4",
+						"ts-api-utils": "^1.3.0"
 					}
 				},
 				"@typescript-eslint/types": {
-					"version": "5.11.0",
-					"bundled": true,
+					"version": "7.18.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+					"integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
 					"dev": true
 				},
 				"@typescript-eslint/typescript-estree": {
-					"version": "5.11.0",
-					"bundled": true,
+					"version": "7.18.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+					"integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "5.11.0",
-						"@typescript-eslint/visitor-keys": "5.11.0",
-						"debug": "^4.3.2",
-						"globby": "^11.0.4",
+						"@typescript-eslint/types": "7.18.0",
+						"@typescript-eslint/visitor-keys": "7.18.0",
+						"debug": "^4.3.4",
+						"globby": "^11.1.0",
 						"is-glob": "^4.0.3",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
+						"minimatch": "^9.0.4",
+						"semver": "^7.6.0",
+						"ts-api-utils": "^1.3.0"
 					},
 					"dependencies": {
 						"globby": {
 							"version": "11.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+							"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 							"dev": true,
 							"requires": {
 								"array-union": "^2.1.0",
@@ -32355,44 +34140,44 @@
 								"slash": "^3.0.0"
 							}
 						},
-						"ignore": {
-							"version": "5.2.0",
-							"bundled": true,
-							"dev": true
+						"minimatch": {
+							"version": "9.0.5",
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+							"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+							"dev": true,
+							"requires": {
+								"brace-expansion": "^2.0.1"
+							}
 						},
 						"slash": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+							"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 							"dev": true
 						}
 					}
 				},
 				"@typescript-eslint/utils": {
-					"version": "5.11.0",
-					"bundled": true,
+					"version": "7.18.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+					"integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
 					"dev": true,
 					"requires": {
-						"@types/json-schema": "^7.0.9",
-						"@typescript-eslint/scope-manager": "5.11.0",
-						"@typescript-eslint/types": "5.11.0",
-						"@typescript-eslint/typescript-estree": "5.11.0",
-						"eslint-scope": "^5.1.1",
-						"eslint-utils": "^3.0.0"
+						"@eslint-community/eslint-utils": "^4.4.0",
+						"@typescript-eslint/scope-manager": "7.18.0",
+						"@typescript-eslint/types": "7.18.0",
+						"@typescript-eslint/typescript-estree": "7.18.0"
 					}
 				},
 				"@typescript-eslint/visitor-keys": {
-					"version": "5.11.0",
-					"bundled": true,
+					"version": "7.18.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+					"integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "5.11.0",
-						"eslint-visitor-keys": "^3.0.0"
+						"@typescript-eslint/types": "7.18.0",
+						"eslint-visitor-keys": "^3.4.3"
 					}
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
 				},
 				"arrify": {
 					"version": "3.0.0",
@@ -32400,52 +34185,32 @@
 					"integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
 					"dev": true
 				},
-				"braces": {
-					"version": "3.0.2",
-					"bundled": true,
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 					"dev": true,
 					"requires": {
-						"fill-range": "^7.0.1"
+						"balanced-match": "^1.0.0"
 					}
 				},
-				"camelcase": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-					"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+				"ci-info": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+					"integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
 					"dev": true
 				},
-				"camelcase-keys": {
-					"version": "7.0.2",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
-					"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+				"cosmiconfig": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+					"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^6.3.0",
-						"map-obj": "^4.1.0",
-						"quick-lru": "^5.1.1",
-						"type-fest": "^1.2.1"
+						"env-paths": "^2.2.1",
+						"import-fresh": "^3.3.0",
+						"js-yaml": "^4.1.0",
+						"parse-json": "^5.2.0"
 					}
-				},
-				"debug": {
-					"version": "4.3.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.1.2",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"decamelize": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
-					"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
-					"dev": true
 				},
 				"define-lazy-prop": {
 					"version": "3.0.0",
@@ -32453,448 +34218,192 @@
 					"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
 					"dev": true
 				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"bundled": true,
+				"eslint": {
+					"version": "8.57.1",
+					"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+					"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
 					"dev": true,
 					"requires": {
-						"path-type": "^4.0.0"
+						"@eslint-community/eslint-utils": "^4.2.0",
+						"@eslint-community/regexpp": "^4.6.1",
+						"@eslint/eslintrc": "^2.1.4",
+						"@eslint/js": "8.57.1",
+						"@humanwhocodes/config-array": "^0.13.0",
+						"@humanwhocodes/module-importer": "^1.0.1",
+						"@nodelib/fs.walk": "^1.2.8",
+						"@ungap/structured-clone": "^1.2.0",
+						"ajv": "^6.12.4",
+						"chalk": "^4.0.0",
+						"cross-spawn": "^7.0.2",
+						"debug": "^4.3.2",
+						"doctrine": "^3.0.0",
+						"escape-string-regexp": "^4.0.0",
+						"eslint-scope": "^7.2.2",
+						"eslint-visitor-keys": "^3.4.3",
+						"espree": "^9.6.1",
+						"esquery": "^1.4.2",
+						"esutils": "^2.0.2",
+						"fast-deep-equal": "^3.1.3",
+						"file-entry-cache": "^6.0.1",
+						"find-up": "^5.0.0",
+						"glob-parent": "^6.0.2",
+						"globals": "^13.19.0",
+						"graphemer": "^1.4.0",
+						"ignore": "^5.2.0",
+						"imurmurhash": "^0.1.4",
+						"is-glob": "^4.0.0",
+						"is-path-inside": "^3.0.3",
+						"js-yaml": "^4.1.0",
+						"json-stable-stringify-without-jsonify": "^1.0.1",
+						"levn": "^0.4.1",
+						"lodash.merge": "^4.6.2",
+						"minimatch": "^3.1.2",
+						"natural-compare": "^1.4.0",
+						"optionator": "^0.9.3",
+						"strip-ansi": "^6.0.1",
+						"text-table": "^0.2.0"
+					},
+					"dependencies": {
+						"@eslint/eslintrc": {
+							"version": "2.1.4",
+							"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+							"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+							"dev": true,
+							"requires": {
+								"ajv": "^6.12.4",
+								"debug": "^4.3.2",
+								"espree": "^9.6.0",
+								"globals": "^13.19.0",
+								"ignore": "^5.2.0",
+								"import-fresh": "^3.2.1",
+								"js-yaml": "^4.1.0",
+								"minimatch": "^3.1.2",
+								"strip-json-comments": "^3.1.1"
+							}
+						}
+					}
+				},
+				"eslint-config-xo": {
+					"version": "0.45.0",
+					"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.45.0.tgz",
+					"integrity": "sha512-T30F2S2HKKmr/RoHopKE7wMUMWrsLMab1qFl2WyFJjETbD+l7p4hSQWpTVGW7TEbSKG1QBekwf6Jn9ZDPA6thA==",
+					"dev": true,
+					"requires": {
+						"confusing-browser-globals": "1.0.11"
 					}
 				},
 				"eslint-config-xo-typescript": {
-					"version": "0.50.0",
-					"bundled": true,
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-5.0.0.tgz",
+					"integrity": "sha512-ukAYCKf3p039pRai7hb6xaomZzsKlCjV5qx3NbYe27UC7Nz75If1HcpQL5sNW2b5aH8+Axb6dIIv28+bVtwlVQ==",
 					"dev": true,
 					"requires": {}
 				},
+				"eslint-plugin-unicorn": {
+					"version": "54.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-54.0.0.tgz",
+					"integrity": "sha512-XxYLRiYtAWiAjPv6z4JREby1TAE2byBC7wlh0V4vWDCpccOSU1KovWV//jqPXF6bq3WKxqX9rdjoRQ1EhdmNdQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.24.5",
+						"@eslint-community/eslint-utils": "^4.4.0",
+						"@eslint/eslintrc": "^3.0.2",
+						"ci-info": "^4.0.0",
+						"clean-regexp": "^1.0.0",
+						"core-js-compat": "^3.37.0",
+						"esquery": "^1.5.0",
+						"indent-string": "^4.0.0",
+						"is-builtin-module": "^3.2.1",
+						"jsesc": "^3.0.2",
+						"pluralize": "^8.0.0",
+						"read-pkg-up": "^7.0.1",
+						"regexp-tree": "^0.1.27",
+						"regjsparser": "^0.10.0",
+						"semver": "^7.6.1",
+						"strip-indent": "^3.0.0"
+					}
+				},
 				"eslint-scope": {
-					"version": "5.1.1",
-					"bundled": true,
+					"version": "7.2.2",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+					"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.3.0",
-						"estraverse": "^4.1.1"
-					},
-					"dependencies": {
-						"estraverse": {
-							"version": "4.3.0",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"eslint-utils": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"eslint-visitor-keys": "^2.0.0"
-					},
-					"dependencies": {
-						"eslint-visitor-keys": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true
-						}
+						"estraverse": "^5.2.0"
 					}
 				},
 				"eslint-visitor-keys": {
-					"version": "3.2.0",
-					"bundled": true,
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+					"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 					"dev": true
 				},
-				"esrecurse": {
-					"version": "4.3.0",
-					"bundled": true,
+				"espree": {
+					"version": "9.6.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+					"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 					"dev": true,
 					"requires": {
-						"estraverse": "^5.2.0"
+						"acorn": "^8.9.0",
+						"acorn-jsx": "^5.3.2",
+						"eslint-visitor-keys": "^3.4.1"
 					}
 				},
 				"estraverse": {
 					"version": "5.3.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
-				},
-				"fast-glob": {
-					"version": "3.2.11",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.2",
-						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.2",
-						"merge2": "^1.3.0",
-						"micromatch": "^4.0.4"
-					}
-				},
-				"fastq": {
-					"version": "1.13.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"reusify": "^1.0.4"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"find-up": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-					"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^7.1.0",
-						"path-exists": "^5.0.0"
-					}
-				},
-				"functional-red-black-tree": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"glob-parent": {
-					"version": "5.1.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
 				},
 				"globby": {
-					"version": "13.1.3",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
-					"integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+					"version": "14.0.2",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+					"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
 					"dev": true,
 					"requires": {
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.2.11",
-						"ignore": "^5.2.0",
-						"merge2": "^1.4.1",
-						"slash": "^4.0.0"
+						"@sindresorhus/merge-streams": "^2.1.0",
+						"fast-glob": "^3.3.2",
+						"ignore": "^5.2.4",
+						"path-type": "^5.0.0",
+						"slash": "^5.1.0",
+						"unicorn-magic": "^0.1.0"
 					}
 				},
-				"hosted-git-info": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"indent-string": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-					"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+				"jsesc": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+					"integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
 					"dev": true
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"locate-path": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
-					"integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^6.0.0"
-					}
-				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
 				},
 				"meow": {
-					"version": "10.1.5",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
-					"integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
-					"dev": true,
-					"requires": {
-						"@types/minimist": "^1.2.2",
-						"camelcase-keys": "^7.0.0",
-						"decamelize": "^5.0.0",
-						"decamelize-keys": "^1.1.0",
-						"hard-rejection": "^2.1.0",
-						"minimist-options": "4.1.0",
-						"normalize-package-data": "^3.0.2",
-						"read-pkg-up": "^8.0.0",
-						"redent": "^4.0.0",
-						"trim-newlines": "^4.0.2",
-						"type-fest": "^1.2.2",
-						"yargs-parser": "^20.2.9"
-					}
-				},
-				"merge2": {
-					"version": "1.4.1",
-					"bundled": true,
-					"dev": true
-				},
-				"micromatch": {
-					"version": "4.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.2.3"
-					}
-				},
-				"normalize-package-data": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "^4.0.1",
-						"is-core-module": "^2.5.0",
-						"semver": "^7.3.4",
-						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"p-limit": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-					"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-					"dev": true,
-					"requires": {
-						"yocto-queue": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-					"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^4.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-					"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+					"version": "13.2.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+					"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
 					"dev": true
 				},
 				"path-type": {
-					"version": "4.0.0",
-					"bundled": true,
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+					"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
 					"dev": true
-				},
-				"picomatch": {
-					"version": "2.3.1",
-					"bundled": true,
-					"dev": true
-				},
-				"queue-microtask": {
-					"version": "1.2.3",
-					"bundled": true,
-					"dev": true
-				},
-				"quick-lru": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-					"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
-					"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
-					"dev": true,
-					"requires": {
-						"@types/normalize-package-data": "^2.4.0",
-						"normalize-package-data": "^3.0.2",
-						"parse-json": "^5.2.0",
-						"type-fest": "^1.0.1"
-					}
-				},
-				"read-pkg-up": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-					"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^5.0.0",
-						"read-pkg": "^6.0.0",
-						"type-fest": "^1.0.1"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-							"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-							"dev": true,
-							"requires": {
-								"locate-path": "^6.0.0",
-								"path-exists": "^4.0.0"
-							}
-						},
-						"locate-path": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-							"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-							"dev": true,
-							"requires": {
-								"p-locate": "^5.0.0"
-							}
-						},
-						"p-limit": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-							"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-							"dev": true,
-							"requires": {
-								"yocto-queue": "^0.1.0"
-							}
-						},
-						"p-locate": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-							"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-							"dev": true,
-							"requires": {
-								"p-limit": "^3.0.2"
-							}
-						},
-						"path-exists": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-							"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-							"dev": true
-						},
-						"yocto-queue": {
-							"version": "0.1.0",
-							"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-							"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-							"dev": true
-						}
-					}
-				},
-				"redent": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-					"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-					"dev": true,
-					"requires": {
-						"indent-string": "^5.0.0",
-						"strip-indent": "^4.0.0"
-					}
-				},
-				"regexpp": {
-					"version": "3.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"reusify": {
-					"version": "1.0.4",
-					"bundled": true,
-					"dev": true
-				},
-				"run-parallel": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"queue-microtask": "^1.2.2"
-					}
 				},
 				"semver": {
-					"version": "7.3.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.6.3",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+					"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+					"dev": true
 				},
 				"slash": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-					"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+					"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 					"dev": true
 				},
-				"strip-indent": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-					"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-					"dev": true,
-					"requires": {
-						"min-indent": "^1.0.1"
-					}
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				},
-				"trim-newlines": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
-					"integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
-					"dev": true
-				},
-				"tslib": {
-					"version": "1.14.1",
-					"bundled": true,
-					"dev": true
-				},
-				"tsutils": {
-					"version": "3.21.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"tslib": "^1.8.1"
-					}
-				},
-				"type-fest": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-					"dev": true
-				},
-				"typescript": {
-					"version": "4.9.5",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-					"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-					"bundled": true,
-					"dev": true
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"yocto-queue": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-					"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+				"unicorn-magic": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+					"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
 					"dev": true
 				}
 			}
@@ -32974,6 +34483,12 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
+		},
+		"yoctocolors": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
+			"integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
 			"dev": true
 		},
 		"zip-dir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
 				"eslint-plugin-react-hooks": "^4.6.0",
 				"jest": "^29.4.3",
 				"jest-environment-jsdom": "^29.4.3",
-				"jest-puppeteer": "^7.0.1",
+				"jest-puppeteer": "^10.1.1",
 				"npm-run-all": "^4.1.5",
 				"parcel": "^2.5.0",
 				"path-browserify": "^1.0.1",
@@ -1214,15 +1214,15 @@
 			}
 		},
 		"node_modules/@jest/environment": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.3.tgz",
-			"integrity": "sha512-dq5S6408IxIa+lr54zeqce+QgI+CJT4nmmA+1yzFgtcsGK8c/EyiUb9XQOgz3BMKrRDfKseeOaxj2eO8LlD3lA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/fake-timers": "^29.4.3",
-				"@jest/types": "^29.4.3",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-mock": "^29.4.3"
+				"jest-mock": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1263,17 +1263,17 @@
 			}
 		},
 		"node_modules/@jest/fake-timers": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.3.tgz",
-			"integrity": "sha512-4Hote2MGcCTWSD2gwl0dwbCpBRHhE6olYEuTj8FMowdg3oQWNKr2YuxenPQYZ7+PfqPY1k98wKDU4Z+Hvd4Tiw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.4.3",
+				"@jest/types": "^29.6.3",
 				"@sinonjs/fake-timers": "^10.0.2",
 				"@types/node": "*",
-				"jest-message-util": "^29.4.3",
-				"jest-mock": "^29.4.3",
-				"jest-util": "^29.4.3"
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1567,12 +1567,12 @@
 			}
 		},
 		"node_modules/@jest/types": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
-			"integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/schemas": "^29.4.3",
+				"@jest/schemas": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^3.0.0",
 				"@types/node": "*",
@@ -3071,9 +3071,9 @@
 			}
 		},
 		"node_modules/@sideway/address": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-			"integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+			"integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
 			"dev": true,
 			"dependencies": {
 				"@hapi/hoek": "^9.0.0"
@@ -4617,15 +4617,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"node_modules/arr-union": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/array-differ": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
@@ -4822,13 +4813,14 @@
 			"dev": true
 		},
 		"node_modules/axios": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-			"integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+			"integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
 			"dev": true,
 			"dependencies": {
-				"follow-redirects": "^1.14.9",
-				"form-data": "^4.0.0"
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/babel-plugin-istanbul": {
@@ -5751,46 +5743,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8"
-			}
-		},
-		"node_modules/clone-deep": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-			"integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
-			"dev": true,
-			"dependencies": {
-				"for-own": "^0.1.3",
-				"is-plain-object": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"lazy-cache": "^1.0.3",
-				"shallow-clone": "^0.1.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/clone-deep/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/clone-deep/node_modules/kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-			"dev": true,
-			"dependencies": {
-				"is-buffer": "^1.1.5"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/clsx": {
@@ -7977,12 +7929,12 @@
 			}
 		},
 		"node_modules/expect-puppeteer": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-7.0.1.tgz",
-			"integrity": "sha512-v0JGhtGmiTMAaPbvEekxSXMLhK6wY4pVr/UNhYgCHwom5MXaV1qTjWGZv9MAMLJe9bqDeN8Mh1hIL/JVkr6+qA==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-10.1.1.tgz",
+			"integrity": "sha512-tbK/lItqbLn5ZmM/eXP5OYGmR/yYiJVCc8VYZdhRztyaeiTb+M9+j3pU9TauX7kFbJtpX0dgEgrSSUlqaOqU5g==",
 			"dev": true,
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=16"
 			}
 		},
 		"node_modules/expect/node_modules/jest-diff": {
@@ -8425,9 +8377,9 @@
 			"dev": true
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8451,27 +8403,6 @@
 			"dev": true,
 			"dependencies": {
 				"is-callable": "^1.1.3"
-			}
-		},
-		"node_modules/for-in": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
-			"dev": true,
-			"dependencies": {
-				"for-in": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/forever-agent": {
@@ -9571,12 +9502,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
-		},
 		"node_modules/is-builtin-module": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
@@ -9656,15 +9581,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-extendable": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -10083,15 +9999,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
-		},
-		"node_modules/isobject": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/isstream": {
 			"version": "0.1.2",
@@ -10538,21 +10445,21 @@
 			}
 		},
 		"node_modules/jest-dev-server": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-7.0.1.tgz",
-			"integrity": "sha512-0GXo3KEtPU+WaDNYYZIieS9wrdNk5CwpB7oi2tiMIUxTKf3CzWFy6zZE/NN6TgAdxUqjFg7IzZIOBibczzGalA==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.1.1.tgz",
+			"integrity": "sha512-Yk9gmW/io2udONlhdrsC69ZGYM2CISvGItyYk9zD5QK3tGq8ZAJP27NDHma4hI6ey/zcaiqbrDkIf7dmpHq86w==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"cwd": "^0.10.0",
 				"find-process": "^1.4.7",
 				"prompts": "^2.4.2",
-				"spawnd": "^7.0.0",
+				"spawnd": "^10.1.1",
 				"tree-kill": "^1.2.2",
-				"wait-on": "^7.0.1"
+				"wait-on": "^7.2.0"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=16"
 			}
 		},
 		"node_modules/jest-docblock": {
@@ -10620,36 +10527,62 @@
 			}
 		},
 		"node_modules/jest-environment-node": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.4.3.tgz",
-			"integrity": "sha512-gAiEnSKF104fsGDXNkwk49jD/0N0Bqu2K9+aMQXA6avzsA9H3Fiv1PW2D+gzbOSR705bWd2wJZRFEFpV0tXISg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/environment": "^29.4.3",
-				"@jest/fake-timers": "^29.4.3",
-				"@jest/types": "^29.4.3",
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-mock": "^29.4.3",
-				"jest-util": "^29.4.3"
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-environment-puppeteer": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-7.0.1.tgz",
-			"integrity": "sha512-ZfNK2jfY4Ru7WQW9aq/WStkyf6I74Y141j1FTGiZtKfj6xh058N+vtWnt7o1yw3SOumrIAL9lMdKWZxWZRVHuA==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.1.1.tgz",
+			"integrity": "sha512-xg+94eL4LeJ3rFLtF9TCIvs3xbx0IJ3W4HEEpaZdkszZt1PbOosqOwbkLEtCeBXePwPproag7nLQz3/vfmp1Qw==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
-				"cwd": "^0.10.0",
-				"jest-dev-server": "^7.0.1",
-				"jest-environment-node": "^29.4.1",
-				"merge-deep": "^3.0.3"
+				"cosmiconfig": "^8.3.6",
+				"deepmerge": "^4.3.1",
+				"jest-dev-server": "^10.1.1",
+				"jest-environment-node": "^29.7.0"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=16"
+			}
+		},
+		"node_modules/jest-environment-puppeteer/node_modules/cosmiconfig": {
+			"version": "8.3.6",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+			"dev": true,
+			"dependencies": {
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0",
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/jest-leak-detector": {
@@ -10675,18 +10608,18 @@
 			}
 		},
 		"node_modules/jest-message-util": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.3.tgz",
-			"integrity": "sha512-1Y8Zd4ZCN7o/QnWdMmT76If8LuDv23Z1DRovBj/vcSFNlGCJGoO8D1nJDw1AdyAGUk0myDLFGN5RbNeJyCRGCw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.4.3",
+				"@jest/types": "^29.6.3",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.9",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^29.4.3",
+				"pretty-format": "^29.7.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
 			},
@@ -10695,14 +10628,14 @@
 			}
 		},
 		"node_modules/jest-mock": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.3.tgz",
-			"integrity": "sha512-LjFgMg+xed9BdkPMyIJh+r3KeHt1klXPJYBULXVVAkbTaaKjPX1o1uVCAZADMEp/kOxGTwy/Ot8XbvgItOrHEg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.4.3",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-util": "^29.4.3"
+				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -10726,16 +10659,16 @@
 			}
 		},
 		"node_modules/jest-puppeteer": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-7.0.1.tgz",
-			"integrity": "sha512-B1VAGvYNwugSBjQa2rFBUrqOQ2oU/mzBYpmz0+xXOsy2hGUW9u00nS+dfAdCcE0VWenFzgQ6pVJavkCQvi0HEQ==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-10.1.1.tgz",
+			"integrity": "sha512-iXY/ZqSOkeF6ntKU2pvQw+Zj6WNPkJVNOGNy+DeVaWPQJLbBeRo89BtDWtYXzGoN8ilvYUChQlvaEdGVbEYX4g==",
 			"dev": true,
 			"dependencies": {
-				"expect-puppeteer": "^7.0.1",
-				"jest-environment-puppeteer": "^7.0.1"
+				"expect-puppeteer": "^10.1.1",
+				"jest-environment-puppeteer": "^10.1.1"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=16"
 			},
 			"peerDependencies": {
 				"puppeteer": ">=19"
@@ -11369,12 +11302,12 @@
 			"dev": true
 		},
 		"node_modules/jest-util": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.3.tgz",
-			"integrity": "sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.4.3",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"ci-info": "^3.2.0",
@@ -11486,14 +11419,14 @@
 			}
 		},
 		"node_modules/joi": {
-			"version": "17.8.3",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-17.8.3.tgz",
-			"integrity": "sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==",
+			"version": "17.13.3",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+			"integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
 			"dev": true,
 			"dependencies": {
-				"@hapi/hoek": "^9.0.0",
-				"@hapi/topo": "^5.0.0",
-				"@sideway/address": "^4.1.3",
+				"@hapi/hoek": "^9.3.0",
+				"@hapi/topo": "^5.1.0",
+				"@sideway/address": "^4.1.5",
 				"@sideway/formula": "^3.0.1",
 				"@sideway/pinpoint": "^2.0.0"
 			}
@@ -11861,15 +11794,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/lcid": {
@@ -12559,32 +12483,6 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
-		"node_modules/merge-deep": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
-			"integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
-			"dev": true,
-			"dependencies": {
-				"arr-union": "^3.1.0",
-				"clone-deep": "^0.2.4",
-				"kind-of": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/merge-deep/node_modules/kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-			"dev": true,
-			"dependencies": {
-				"is-buffer": "^1.1.5"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -12683,9 +12581,9 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -12719,28 +12617,6 @@
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
 			"integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
 			"dev": true
-		},
-		"node_modules/mixin-object": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-			"integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
-			"dev": true,
-			"dependencies": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mixin-object/node_modules/for-in": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-			"integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/mkdirp": {
 			"version": "0.5.6",
@@ -15359,9 +15235,9 @@
 			}
 		},
 		"node_modules/rxjs": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-			"integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^2.1.0"
@@ -15600,42 +15476,6 @@
 				"sha.js": "bin.js"
 			}
 		},
-		"node_modules/shallow-clone": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-			"integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
-			"dev": true,
-			"dependencies": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^2.0.1",
-				"lazy-cache": "^0.2.3",
-				"mixin-object": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/shallow-clone/node_modules/kind-of": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-			"integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
-			"dev": true,
-			"dependencies": {
-				"is-buffer": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/shallow-clone/node_modules/lazy-cache": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-			"integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -15804,17 +15644,28 @@
 			}
 		},
 		"node_modules/spawnd": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-7.0.0.tgz",
-			"integrity": "sha512-TU/M4qYmigdeET4HTR7l9nqySTTvStWM6rW8QyixXRxWn90E718y5Q31ZVXyG7VEqT6oo6EUvE9zk4rGU39HbA==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.1.1.tgz",
+			"integrity": "sha512-kTim9sz8KuKX7ZcO8imlvEvbaJmFtFhT5tKS0WP5FRlmWLH5Pd9qj9u29nbMrvDcJPj8ltwOG+QAiZq928GKCw==",
 			"dev": true,
 			"dependencies": {
-				"exit": "^0.1.2",
-				"signal-exit": "^3.0.7",
+				"signal-exit": "^4.1.0",
 				"tree-kill": "^1.2.2"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=16"
+			}
+		},
+		"node_modules/spawnd/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/spdx-correct": {
@@ -17246,16 +17097,16 @@
 			}
 		},
 		"node_modules/wait-on": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-			"integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+			"integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
 			"dev": true,
 			"dependencies": {
-				"axios": "^0.27.2",
-				"joi": "^17.7.0",
+				"axios": "^1.6.1",
+				"joi": "^17.11.0",
 				"lodash": "^4.17.21",
-				"minimist": "^1.2.7",
-				"rxjs": "^7.8.0"
+				"minimist": "^1.2.8",
+				"rxjs": "^7.8.1"
 			},
 			"bin": {
 				"wait-on": "bin/wait-on"
@@ -20111,15 +19962,15 @@
 			}
 		},
 		"@jest/environment": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.3.tgz",
-			"integrity": "sha512-dq5S6408IxIa+lr54zeqce+QgI+CJT4nmmA+1yzFgtcsGK8c/EyiUb9XQOgz3BMKrRDfKseeOaxj2eO8LlD3lA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^29.4.3",
-				"@jest/types": "^29.4.3",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-mock": "^29.4.3"
+				"jest-mock": "^29.7.0"
 			}
 		},
 		"@jest/expect": {
@@ -20150,17 +20001,17 @@
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.3.tgz",
-			"integrity": "sha512-4Hote2MGcCTWSD2gwl0dwbCpBRHhE6olYEuTj8FMowdg3oQWNKr2YuxenPQYZ7+PfqPY1k98wKDU4Z+Hvd4Tiw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.4.3",
+				"@jest/types": "^29.6.3",
 				"@sinonjs/fake-timers": "^10.0.2",
 				"@types/node": "*",
-				"jest-message-util": "^29.4.3",
-				"jest-mock": "^29.4.3",
-				"jest-util": "^29.4.3"
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			}
 		},
 		"@jest/globals": {
@@ -20389,12 +20240,12 @@
 			}
 		},
 		"@jest/types": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
-			"integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
 			"dev": true,
 			"requires": {
-				"@jest/schemas": "^29.4.3",
+				"@jest/schemas": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^3.0.0",
 				"@types/node": "*",
@@ -21358,9 +21209,9 @@
 			"integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
 		},
 		"@sideway/address": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-			"integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+			"integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
 			"dev": true,
 			"requires": {
 				"@hapi/hoek": "^9.0.0"
@@ -22635,12 +22486,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"arr-union": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-			"dev": true
-		},
 		"array-differ": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
@@ -22786,13 +22631,14 @@
 			"dev": true
 		},
 		"axios": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-			"integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+			"integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
 			"dev": true,
 			"requires": {
-				"follow-redirects": "^1.14.9",
-				"form-data": "^4.0.0"
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -23441,39 +23287,6 @@
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
 			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
 			"dev": true
-		},
-		"clone-deep": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-			"integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
-			"dev": true,
-			"requires": {
-				"for-own": "^0.1.3",
-				"is-plain-object": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"lazy-cache": "^1.0.3",
-				"shallow-clone": "^0.1.2"
-			},
-			"dependencies": {
-				"is-plain-object": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-					"dev": true,
-					"requires": {
-						"isobject": "^3.0.1"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
-			}
 		},
 		"clsx": {
 			"version": "1.2.1",
@@ -25137,9 +24950,9 @@
 			}
 		},
 		"expect-puppeteer": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-7.0.1.tgz",
-			"integrity": "sha512-v0JGhtGmiTMAaPbvEekxSXMLhK6wY4pVr/UNhYgCHwom5MXaV1qTjWGZv9MAMLJe9bqDeN8Mh1hIL/JVkr6+qA==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-10.1.1.tgz",
+			"integrity": "sha512-tbK/lItqbLn5ZmM/eXP5OYGmR/yYiJVCc8VYZdhRztyaeiTb+M9+j3pU9TauX7kFbJtpX0dgEgrSSUlqaOqU5g==",
 			"dev": true
 		},
 		"extend": {
@@ -25460,9 +25273,9 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
 			"dev": true
 		},
 		"for-each": {
@@ -25472,21 +25285,6 @@
 			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.3"
-			}
-		},
-		"for-in": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
-			"dev": true
-		},
-		"for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
-			"dev": true,
-			"requires": {
-				"for-in": "^1.0.1"
 			}
 		},
 		"forever-agent": {
@@ -26247,12 +26045,6 @@
 				"has-tostringtag": "^1.0.0"
 			}
 		},
-		"is-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
-		},
 		"is-builtin-module": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
@@ -26299,12 +26091,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
 			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-			"dev": true
-		},
-		"is-extendable": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true
 		},
 		"is-extglob": {
@@ -26608,12 +26394,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
-		},
-		"isobject": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
 			"dev": true
 		},
 		"isstream": {
@@ -26950,18 +26730,18 @@
 			}
 		},
 		"jest-dev-server": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-7.0.1.tgz",
-			"integrity": "sha512-0GXo3KEtPU+WaDNYYZIieS9wrdNk5CwpB7oi2tiMIUxTKf3CzWFy6zZE/NN6TgAdxUqjFg7IzZIOBibczzGalA==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.1.1.tgz",
+			"integrity": "sha512-Yk9gmW/io2udONlhdrsC69ZGYM2CISvGItyYk9zD5QK3tGq8ZAJP27NDHma4hI6ey/zcaiqbrDkIf7dmpHq86w==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.2",
 				"cwd": "^0.10.0",
 				"find-process": "^1.4.7",
 				"prompts": "^2.4.2",
-				"spawnd": "^7.0.0",
+				"spawnd": "^10.1.1",
 				"tree-kill": "^1.2.2",
-				"wait-on": "^7.0.1"
+				"wait-on": "^7.2.0"
 			}
 		},
 		"jest-docblock": {
@@ -27011,30 +26791,44 @@
 			}
 		},
 		"jest-environment-node": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.4.3.tgz",
-			"integrity": "sha512-gAiEnSKF104fsGDXNkwk49jD/0N0Bqu2K9+aMQXA6avzsA9H3Fiv1PW2D+gzbOSR705bWd2wJZRFEFpV0tXISg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^29.4.3",
-				"@jest/fake-timers": "^29.4.3",
-				"@jest/types": "^29.4.3",
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-mock": "^29.4.3",
-				"jest-util": "^29.4.3"
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			}
 		},
 		"jest-environment-puppeteer": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-7.0.1.tgz",
-			"integrity": "sha512-ZfNK2jfY4Ru7WQW9aq/WStkyf6I74Y141j1FTGiZtKfj6xh058N+vtWnt7o1yw3SOumrIAL9lMdKWZxWZRVHuA==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.1.1.tgz",
+			"integrity": "sha512-xg+94eL4LeJ3rFLtF9TCIvs3xbx0IJ3W4HEEpaZdkszZt1PbOosqOwbkLEtCeBXePwPproag7nLQz3/vfmp1Qw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.2",
-				"cwd": "^0.10.0",
-				"jest-dev-server": "^7.0.1",
-				"jest-environment-node": "^29.4.1",
-				"merge-deep": "^3.0.3"
+				"cosmiconfig": "^8.3.6",
+				"deepmerge": "^4.3.1",
+				"jest-dev-server": "^10.1.1",
+				"jest-environment-node": "^29.7.0"
+			},
+			"dependencies": {
+				"cosmiconfig": {
+					"version": "8.3.6",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+					"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^3.3.0",
+						"js-yaml": "^4.1.0",
+						"parse-json": "^5.2.0",
+						"path-type": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-leak-detector": {
@@ -27056,31 +26850,31 @@
 			}
 		},
 		"jest-message-util": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.3.tgz",
-			"integrity": "sha512-1Y8Zd4ZCN7o/QnWdMmT76If8LuDv23Z1DRovBj/vcSFNlGCJGoO8D1nJDw1AdyAGUk0myDLFGN5RbNeJyCRGCw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.4.3",
+				"@jest/types": "^29.6.3",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.9",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^29.4.3",
+				"pretty-format": "^29.7.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
 			}
 		},
 		"jest-mock": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.3.tgz",
-			"integrity": "sha512-LjFgMg+xed9BdkPMyIJh+r3KeHt1klXPJYBULXVVAkbTaaKjPX1o1uVCAZADMEp/kOxGTwy/Ot8XbvgItOrHEg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.4.3",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-util": "^29.4.3"
+				"jest-util": "^29.7.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -27091,13 +26885,13 @@
 			"requires": {}
 		},
 		"jest-puppeteer": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-7.0.1.tgz",
-			"integrity": "sha512-B1VAGvYNwugSBjQa2rFBUrqOQ2oU/mzBYpmz0+xXOsy2hGUW9u00nS+dfAdCcE0VWenFzgQ6pVJavkCQvi0HEQ==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-10.1.1.tgz",
+			"integrity": "sha512-iXY/ZqSOkeF6ntKU2pvQw+Zj6WNPkJVNOGNy+DeVaWPQJLbBeRo89BtDWtYXzGoN8ilvYUChQlvaEdGVbEYX4g==",
 			"dev": true,
 			"requires": {
-				"expect-puppeteer": "^7.0.1",
-				"jest-environment-puppeteer": "^7.0.1"
+				"expect-puppeteer": "^10.1.1",
+				"jest-environment-puppeteer": "^10.1.1"
 			}
 		},
 		"jest-resolve": {
@@ -27610,12 +27404,12 @@
 			}
 		},
 		"jest-util": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.3.tgz",
-			"integrity": "sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.4.3",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"ci-info": "^3.2.0",
@@ -27700,14 +27494,14 @@
 			}
 		},
 		"joi": {
-			"version": "17.8.3",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-17.8.3.tgz",
-			"integrity": "sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==",
+			"version": "17.13.3",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+			"integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
 			"dev": true,
 			"requires": {
-				"@hapi/hoek": "^9.0.0",
-				"@hapi/topo": "^5.0.0",
-				"@sideway/address": "^4.1.3",
+				"@hapi/hoek": "^9.3.0",
+				"@hapi/topo": "^5.1.0",
+				"@sideway/address": "^4.1.5",
 				"@sideway/formula": "^3.0.1",
 				"@sideway/pinpoint": "^2.0.0"
 			}
@@ -28013,12 +27807,6 @@
 			"requires": {
 				"package-json": "^8.1.0"
 			}
-		},
-		"lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
-			"dev": true
 		},
 		"lcid": {
 			"version": "3.1.1",
@@ -28481,28 +28269,6 @@
 				}
 			}
 		},
-		"merge-deep": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
-			"integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
-			"dev": true,
-			"requires": {
-				"arr-union": "^3.1.0",
-				"clone-deep": "^0.2.4",
-				"kind-of": "^3.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
-			}
-		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -28574,9 +28340,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"dev": true
 		},
 		"minimist-options": {
@@ -28601,24 +28367,6 @@
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
 			"integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
 			"dev": true
-		},
-		"mixin-object": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-			"integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
-			"dev": true,
-			"requires": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
-			},
-			"dependencies": {
-				"for-in": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-					"integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
-					"dev": true
-				}
-			}
 		},
 		"mkdirp": {
 			"version": "0.5.6",
@@ -30551,9 +30299,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-			"integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
 			"dev": true,
 			"requires": {
 				"tslib": "^2.1.0"
@@ -30739,35 +30487,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"shallow-clone": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-			"integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
-			"dev": true,
-			"requires": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^2.0.1",
-				"lazy-cache": "^0.2.3",
-				"mixin-object": "^2.0.1"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-					"integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.0.2"
-					}
-				},
-				"lazy-cache": {
-					"version": "0.2.7",
-					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-					"integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
-					"dev": true
-				}
-			}
-		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -30910,14 +30629,21 @@
 			}
 		},
 		"spawnd": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-7.0.0.tgz",
-			"integrity": "sha512-TU/M4qYmigdeET4HTR7l9nqySTTvStWM6rW8QyixXRxWn90E718y5Q31ZVXyG7VEqT6oo6EUvE9zk4rGU39HbA==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.1.1.tgz",
+			"integrity": "sha512-kTim9sz8KuKX7ZcO8imlvEvbaJmFtFhT5tKS0WP5FRlmWLH5Pd9qj9u29nbMrvDcJPj8ltwOG+QAiZq928GKCw==",
 			"dev": true,
 			"requires": {
-				"exit": "^0.1.2",
-				"signal-exit": "^3.0.7",
+				"signal-exit": "^4.1.0",
 				"tree-kill": "^1.2.2"
+			},
+			"dependencies": {
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				}
 			}
 		},
 		"spdx-correct": {
@@ -31982,16 +31708,16 @@
 			}
 		},
 		"wait-on": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-			"integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+			"integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
 			"dev": true,
 			"requires": {
-				"axios": "^0.27.2",
-				"joi": "^17.7.0",
+				"axios": "^1.6.1",
+				"joi": "^17.11.0",
 				"lodash": "^4.17.21",
-				"minimist": "^1.2.7",
-				"rxjs": "^7.8.0"
+				"minimist": "^1.2.8",
+				"rxjs": "^7.8.1"
 			}
 		},
 		"walker": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,12 +83,13 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.18.6"
+				"@babel/highlight": "^7.24.7",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -143,13 +144,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-			"integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+			"integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.20.7",
-				"@jridgewell/gen-mapping": "^0.3.2",
+				"@babel/types": "^7.25.6",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
 			},
 			"engines": {
@@ -157,14 +159,14 @@
 			}
 		},
 		"node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/trace-mapping": "^0.3.24"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -203,31 +205,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
 			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
 			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-function-name": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
-			"integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/template": "^7.20.7",
-				"@babel/types": "^7.21.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.18.6"
-			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -297,18 +274,18 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.19.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+			"integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -338,14 +315,15 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -423,10 +401,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
-			"integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+			"integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
 			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.25.6"
+			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -624,34 +605,31 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+			"integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.24.7",
+				"@babel/parser": "^7.25.0",
+				"@babel/types": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
-			"integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+			"integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.20.13",
-				"@babel/types": "^7.20.7",
-				"debug": "^4.1.0",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.25.6",
+				"@babel/parser": "^7.25.6",
+				"@babel/template": "^7.25.0",
+				"@babel/types": "^7.25.6",
+				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -668,13 +646,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.21.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-			"integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+			"integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.19.4",
-				"@babel/helper-validator-identifier": "^7.19.1",
+				"@babel/helper-string-parser": "^7.24.8",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -1628,9 +1606,9 @@
 			}
 		},
 		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -1667,13 +1645,13 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"node_modules/@lezer/common": {
@@ -19276,12 +19254,13 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.18.6"
+				"@babel/highlight": "^7.24.7",
+				"picocolors": "^1.0.0"
 			}
 		},
 		"@babel/compat-data": {
@@ -19322,25 +19301,26 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-			"integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+			"integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.20.7",
-				"@jridgewell/gen-mapping": "^0.3.2",
+				"@babel/types": "^7.25.6",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
 			},
 			"dependencies": {
 				"@jridgewell/gen-mapping": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-					"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+					"version": "0.3.5",
+					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+					"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 					"dev": true,
 					"requires": {
-						"@jridgewell/set-array": "^1.0.1",
+						"@jridgewell/set-array": "^1.2.1",
 						"@jridgewell/sourcemap-codec": "^1.4.10",
-						"@jridgewell/trace-mapping": "^0.3.9"
+						"@jridgewell/trace-mapping": "^0.3.24"
 					}
 				}
 			}
@@ -19371,25 +19351,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
 			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
 			"dev": true
-		},
-		"@babel/helper-function-name": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
-			"integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.20.7",
-				"@babel/types": "^7.21.0"
-			}
-		},
-		"@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.18.6"
-			}
 		},
 		"@babel/helper-module-imports": {
 			"version": "7.18.6",
@@ -19441,15 +19402,15 @@
 			}
 		},
 		"@babel/helper-string-parser": {
-			"version": "7.19.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+			"integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
 			"dev": true
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
@@ -19470,14 +19431,15 @@
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -19539,10 +19501,13 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
-			"integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
-			"dev": true
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+			"integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.25.6"
+			}
 		},
 		"@babel/plugin-syntax-async-generators": {
 			"version": "7.8.4",
@@ -19680,31 +19645,28 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+			"integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.24.7",
+				"@babel/parser": "^7.25.0",
+				"@babel/types": "^7.25.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
-			"integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+			"integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.20.13",
-				"@babel/types": "^7.20.7",
-				"debug": "^4.1.0",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.25.6",
+				"@babel/parser": "^7.25.6",
+				"@babel/template": "^7.25.0",
+				"@babel/types": "^7.25.6",
+				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
 			"dependencies": {
@@ -19717,13 +19679,13 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.21.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-			"integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+			"integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-string-parser": "^7.19.4",
-				"@babel/helper-validator-identifier": "^7.19.1",
+				"@babel/helper-string-parser": "^7.24.8",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -20457,9 +20419,9 @@
 			"dev": true
 		},
 		"@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"dev": true
 		},
 		"@jridgewell/source-map": {
@@ -20492,13 +20454,13 @@
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"@lezer/common": {

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"jest": "^29.4.3",
 		"jest-environment-jsdom": "^29.4.3",
-		"jest-puppeteer": "^7.0.1",
+		"jest-puppeteer": "^10.1.1",
 		"npm-run-all": "^4.1.5",
 		"parcel": "^2.5.0",
 		"path-browserify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,170 +27,6 @@
 		"last 1 Chrome version",
 		"last 1 Firefox version"
 	],
-	"xo": {
-		"extends": [
-			"xo-react",
-			"plugin:react/jsx-runtime"
-		],
-		"parserOptions": {
-			"project": "./tsconfig.xo.json"
-		},
-		"envs": [
-			"browser"
-		],
-		"prettier": "true",
-		"globals": {
-			"page": true,
-			"browser": true,
-			"context": true,
-			"jestPuppeteer": true
-		},
-		"rules": {
-			"no-unused-vars": [
-				"error",
-				{
-					"varsIgnorePattern": "browser"
-				}
-			],
-			"import/extensions": [
-				2,
-				"never",
-				{
-					"png": "always",
-					"html": "always"
-				}
-			],
-			"unicorn/filename-case": [
-				"error",
-				{
-					"cases": {
-						"camelCase": true,
-						"pascalCase": true
-					}
-				}
-			],
-			"@typescript-eslint/naming-convention": [
-				"error",
-				{
-					"selector": "default",
-					"format": [
-						"camelCase"
-					],
-					"leadingUnderscore": "allowSingleOrDouble"
-				},
-				{
-					"selector": "variable",
-					"format": [
-						"camelCase",
-						"PascalCase",
-						"UPPER_CASE"
-					]
-				},
-				{
-					"selector": "parameter",
-					"format": [
-						"camelCase"
-					],
-					"leadingUnderscore": "allowSingleOrDouble"
-				},
-				{
-					"selector": "function",
-					"format": [
-						"camelCase",
-						"PascalCase"
-					],
-					"leadingUnderscore": "allowSingleOrDouble"
-				},
-				{
-					"selector": "memberLike",
-					"modifiers": [
-						"private"
-					],
-					"format": [
-						"camelCase"
-					],
-					"leadingUnderscore": "require"
-				},
-				{
-					"selector": "typeLike",
-					"format": [
-						"PascalCase"
-					]
-				}
-			],
-			"node/prefer-global/process": "off",
-			"complexity": "off",
-			"no-use-extend-native/no-use-extend-native": "off",
-			"unicorn/no-array-callback-reference": "off",
-			"unicorn/prefer-node-protocol": "off",
-			"@typescript-eslint/ban-types": "off",
-			"no-redeclare": "off",
-			"@typescript-eslint/no-redeclare": "off"
-		},
-		"overrides": [
-			{
-				"files": [
-					"src/background/**"
-				],
-				"rules": {
-					"no-restricted-imports": [
-						"error",
-						{
-							"patterns": [
-								{
-									"group": [
-										"**/content/**"
-									],
-									"message": "Modules within /src/background can't import from /src/content"
-								}
-							]
-						}
-					]
-				}
-			},
-			{
-				"files": [
-					"src/content/**"
-				],
-				"rules": {
-					"no-restricted-imports": [
-						"error",
-						{
-							"patterns": [
-								{
-									"group": [
-										"**/background/**"
-									],
-									"message": "Modules within /src/content can't import from /src/background"
-								}
-							]
-						}
-					]
-				}
-			},
-			{
-				"files": [
-					"src/common/**"
-				],
-				"rules": {
-					"no-restricted-imports": [
-						"error",
-						{
-							"patterns": [
-								{
-									"group": [
-										"**/background/**",
-										"**/content/**"
-									],
-									"message": "Modules within /src/content can't import from /src/background or /src/content"
-								}
-							]
-						}
-					]
-				}
-			}
-		]
-	},
 	"prettier": {
 		"trailingComma": "es5",
 		"singleQuote": false,
@@ -252,8 +88,8 @@
 		"eslint-config-xo": "^0.40.0",
 		"eslint-config-xo-react": "^0.27.0",
 		"eslint-config-xo-typescript": "^0.50.0",
-		"eslint-plugin-react": "^7.32.2",
-		"eslint-plugin-react-hooks": "^4.6.0",
+		"eslint-plugin-react": "^7.36.1",
+		"eslint-plugin-react-hooks": "^4.6.2",
 		"jest": "^29.4.3",
 		"jest-environment-jsdom": "^29.4.3",
 		"jest-puppeteer": "^10.1.1",
@@ -270,7 +106,7 @@
 		"ts-unused-exports": "^8.0.5",
 		"typescript": "^5.6.2",
 		"web-ext": "^7.4.0",
-		"xo": "^0.48.0"
+		"xo": "^0.59.3"
 	},
 	"webExt": {
 		"sourceDir": "dist-mv2",

--- a/src/background/actions/closeTabsInWindow.ts
+++ b/src/background/actions/closeTabsInWindow.ts
@@ -1,4 +1,4 @@
-import browser, { Tabs } from "webextension-polyfill";
+import browser, { type Tabs } from "webextension-polyfill";
 import { assertDefined } from "../../typings/TypingUtils";
 import { getCurrentTab, getCurrentTabId } from "../utils/getCurrentTab";
 
@@ -23,42 +23,50 @@ export async function closeTabsInWindow(
 	let filterFunction: (tab: Tabs.Tab) => boolean;
 
 	switch (tabsToClose) {
-		case "other":
+		case "other": {
 			filterFunction = (tab) => tab.id !== currentTabId;
 			break;
+		}
 
-		case "left":
+		case "left": {
 			filterFunction = (tab) => tab.index < currentTab.index;
 			break;
+		}
 
-		case "right":
+		case "right": {
 			filterFunction = (tab) => tab.index > currentTab.index;
 			break;
+		}
 
-		case "leftEnd":
+		case "leftEnd": {
 			assertDefined(amount);
 			filterFunction = (tab) => tab.index < amount;
 			break;
+		}
 
-		case "rightEnd":
+		case "rightEnd": {
 			assertDefined(amount);
 			filterFunction = (tab) => tab.index >= allTabsInWindow.length - amount;
 			break;
+		}
 
-		case "previous":
+		case "previous": {
 			assertDefined(amount);
 			filterFunction = (tab) =>
 				tab.index >= currentTab.index - amount && tab.index < currentTab.index;
 			break;
+		}
 
-		case "next":
+		case "next": {
 			assertDefined(amount);
 			filterFunction = (tab) =>
 				tab.index > currentTab.index && tab.index <= currentTab.index + amount;
 			break;
+		}
 
-		default:
+		default: {
 			break;
+		}
 	}
 
 	const tabsIdsToRemove = allTabsInWindow

--- a/src/background/actions/copyTabInfo.ts
+++ b/src/background/actions/copyTabInfo.ts
@@ -1,9 +1,9 @@
-import { Tabs } from "webextension-polyfill";
+import { type Tabs } from "webextension-polyfill";
 import { promiseWrap } from "../../lib/promiseWrap";
 import { assertDefined } from "../../typings/TypingUtils";
 import { sendRequestToContent } from "../messaging/sendRequestToContent";
 import { notify } from "../utils/notify";
-import { RangoActionCopyLocationProperty } from "../../typings/RangoAction";
+import { type RangoActionCopyLocationProperty } from "../../typings/RangoAction";
 
 export async function getBareTitle(tab: Tabs.Tab) {
 	const [title] = await promiseWrap(

--- a/src/background/actions/focusPreviousTab.ts
+++ b/src/background/actions/focusPreviousTab.ts
@@ -10,7 +10,7 @@ export async function focusPreviousTab() {
 	assertDefined(previousTabs);
 
 	// The last tab id is the current tab so we need to get the one before that
-	const previousTabId = previousTabs[previousTabs.length - 2];
+	const previousTabId = previousTabs.at(-2);
 
 	if (previousTabId) {
 		await browser.tabs.update(previousTabId, { active: true });

--- a/src/background/actions/focusTabByText.ts
+++ b/src/background/actions/focusTabByText.ts
@@ -63,8 +63,8 @@ export async function cycleTabsByText(step: number) {
 		step > 0
 			? selectedIndex % length
 			: selectedIndex < 0
-			? length - 1
-			: selectedIndex;
+				? length - 1
+				: selectedIndex;
 
 	const targetTab = matches[selectedIndex];
 

--- a/src/background/actions/toggleHints.ts
+++ b/src/background/actions/toggleHints.ts
@@ -2,7 +2,7 @@ import { assertDefined } from "../../typings/TypingUtils";
 import { sendRequestToContent } from "../messaging/sendRequestToContent";
 import { getCurrentTab } from "../utils/getCurrentTab";
 import { retrieve, store } from "../../common/storage";
-import { RangoActionUpdateToggles } from "../../typings/RangoAction";
+import { type RangoActionUpdateToggles } from "../../typings/RangoAction";
 
 export async function toggleHintsGlobal() {
 	const hintsToggleGlobal = await retrieve("hintsToggleGlobal");
@@ -20,7 +20,7 @@ export async function updateHintsToggle(
 	const { host, origin, pathname } = new URL(currentTab.url);
 
 	switch (level) {
-		case "everywhere":
+		case "everywhere": {
 			if (enable === undefined) {
 				await store("hintsToggleGlobal", true);
 				await store("hintsToggleTabs", new Map());
@@ -33,6 +33,7 @@ export async function updateHintsToggle(
 			}
 
 			break;
+		}
 
 		case "now": {
 			await sendRequestToContent({
@@ -42,9 +43,10 @@ export async function updateHintsToggle(
 			break;
 		}
 
-		case "global":
-			await store("hintsToggleGlobal", enable === undefined ? true : enable);
+		case "global": {
+			await store("hintsToggleGlobal", enable ?? true);
 			break;
+		}
 
 		case "tab": {
 			const hintsToggleTabs = await retrieve("hintsToggleTabs");
@@ -90,7 +92,8 @@ export async function updateHintsToggle(
 			break;
 		}
 
-		default:
+		default: {
 			break;
+		}
 	}
 }

--- a/src/background/commands/dispatchCommand.ts
+++ b/src/background/commands/dispatchCommand.ts
@@ -1,5 +1,8 @@
-import { ResponseToTalon, TalonAction } from "../../typings/RequestFromTalon";
-import { RangoAction } from "../../typings/RangoAction";
+import {
+	type ResponseToTalon,
+	type TalonAction,
+} from "../../typings/RequestFromTalon";
+import { type RangoAction } from "../../typings/RangoAction";
 import { sendRequestToContent } from "../messaging/sendRequestToContent";
 import { constructTalonResponse } from "../utils/constructTalonResponse";
 import { promiseWrap } from "../../lib/promiseWrap";

--- a/src/background/commands/runBackgroundCommand.ts
+++ b/src/background/commands/runBackgroundCommand.ts
@@ -1,8 +1,8 @@
 import browser from "webextension-polyfill";
 import { retrieve, store } from "../../common/storage";
 import { promiseWrap } from "../../lib/promiseWrap";
-import { RangoAction } from "../../typings/RangoAction";
-import { TalonAction } from "../../typings/RequestFromTalon";
+import { type RangoAction } from "../../typings/RangoAction";
+import { type TalonAction } from "../../typings/RequestFromTalon";
 import { activateTab } from "../actions/activateTab";
 import { closeTabsInWindow } from "../actions/closeTabsInWindow";
 import {
@@ -52,7 +52,7 @@ export async function runBackgroundCommand(
 			break;
 		}
 
-		case "historyGoBack":
+		case "historyGoBack": {
 			try {
 				await sendRequestToContent(command);
 			} catch {
@@ -60,8 +60,9 @@ export async function runBackgroundCommand(
 			}
 
 			break;
+		}
 
-		case "historyGoForward":
+		case "historyGoForward": {
 			try {
 				await sendRequestToContent(command);
 			} catch {
@@ -69,31 +70,37 @@ export async function runBackgroundCommand(
 			}
 
 			break;
+		}
 
-		case "toggleHints":
+		case "toggleHints": {
 			await toggleHintsGlobal();
 			break;
+		}
 
 		case "enableHints": {
 			await updateHintsToggle(command.arg, true);
 			break;
 		}
 
-		case "disableHints":
+		case "disableHints": {
 			await updateHintsToggle(command.arg, false);
 			break;
+		}
 
-		case "resetToggleLevel":
+		case "resetToggleLevel": {
 			await updateHintsToggle(command.arg);
 			break;
+		}
 
-		case "toggleTabMarkers":
+		case "toggleTabMarkers": {
 			await toggleTabMarkers();
 			break;
+		}
 
-		case "toggleKeyboardClicking":
+		case "toggleKeyboardClicking": {
 			await toggleKeyboardClicking();
 			break;
+		}
 
 		// To be removed in v0.5
 		case "includeSingleLetterHints":
@@ -101,9 +108,10 @@ export async function runBackgroundCommand(
 		case "setHintStyle":
 		case "setHintWeight":
 		case "enableUrlInTitle":
-		case "disableUrlInTitle":
+		case "disableUrlInTitle": {
 			await notifySettingRemoved();
 			break;
+		}
 
 		case "increaseHintSize": {
 			const hintFontSize = await retrieve("hintFontSize");
@@ -117,144 +125,176 @@ export async function runBackgroundCommand(
 			break;
 		}
 
-		case "closeOtherTabsInWindow":
+		case "closeOtherTabsInWindow": {
 			await closeTabsInWindow("other");
 			break;
+		}
 
-		case "closeTabsToTheLeftInWindow":
+		case "closeTabsToTheLeftInWindow": {
 			await closeTabsInWindow("left");
 			break;
+		}
 
-		case "closeTabsToTheRightInWindow":
+		case "closeTabsToTheRightInWindow": {
 			await closeTabsInWindow("right");
 			break;
+		}
 
-		case "closeTabsLeftEndInWindow":
+		case "closeTabsLeftEndInWindow": {
 			await closeTabsInWindow("leftEnd", command.arg);
 			break;
+		}
 
-		case "closeTabsRightEndInWindow":
+		case "closeTabsRightEndInWindow": {
 			await closeTabsInWindow("rightEnd", command.arg);
 			break;
+		}
 
-		case "closePreviousTabsInWindow":
+		case "closePreviousTabsInWindow": {
 			await closeTabsInWindow("previous", command.arg);
 			break;
+		}
 
-		case "closeNextTabsInWindow":
+		case "closeNextTabsInWindow": {
 			await closeTabsInWindow("next", command.arg);
 			break;
+		}
 
-		case "cloneCurrentTab":
+		case "cloneCurrentTab": {
 			if (currentTabId) {
 				await browser.tabs.duplicate(currentTabId);
 			}
 
 			break;
+		}
 
-		case "moveCurrentTabToNewWindow":
+		case "moveCurrentTabToNewWindow": {
 			await browser.windows.create({ tabId: currentTabId });
 			break;
+		}
 
-		case "focusPreviousTab":
+		case "focusPreviousTab": {
 			await focusPreviousTab();
 			break;
+		}
 
-		case "focusNextTabWithSound":
+		case "focusNextTabWithSound": {
 			await focusNextTabWithSound();
 			break;
+		}
 
-		case "focusNextMutedTab":
+		case "focusNextMutedTab": {
 			await focusNextMutedTab();
 			break;
+		}
 
-		case "focusNextAudibleTab":
+		case "focusNextAudibleTab": {
 			await focusNextAudibleTab();
 			break;
+		}
 
-		case "focusTabLastSounded":
+		case "focusTabLastSounded": {
 			await focusTabLastSounded();
 			break;
+		}
 
-		case "muteCurrentTab":
+		case "muteCurrentTab": {
 			await muteTab();
 			break;
+		}
 
-		case "unmuteCurrentTab":
+		case "unmuteCurrentTab": {
 			await muteTab(undefined, false);
 			break;
+		}
 
-		case "muteTab":
+		case "muteTab": {
 			await muteTab(command.target);
 			break;
+		}
 
-		case "unmuteTab":
+		case "unmuteTab": {
 			await muteTab(command.target, false);
 			break;
+		}
 
-		case "muteNextTabWithSound":
+		case "muteNextTabWithSound": {
 			await muteNextTabWithSound();
 			break;
+		}
 
-		case "unmuteNextMutedTab":
+		case "unmuteNextMutedTab": {
 			await unmuteNextMutedTab();
 			break;
+		}
 
-		case "muteAllTabsWithSound":
+		case "muteAllTabsWithSound": {
 			await muteAllTabsWithSound();
 			break;
+		}
 
-		case "unmuteAllMutedTabs":
+		case "unmuteAllMutedTabs": {
 			await unmuteAllMutedTabs();
 			break;
+		}
 
-		case "copyLocationProperty":
+		case "copyLocationProperty": {
 			if (currentTab) {
 				return copyLocationProperty(currentTab, command.arg);
 			}
 
 			break;
+		}
 
-		case "getBareTitle":
+		case "getBareTitle": {
 			if (currentTab) {
 				const title = await getBareTitle(currentTab);
 				return [{ name: "responseValue", value: title }];
 			}
 
 			break;
+		}
 
-		case "copyCurrentTabMarkdownUrl":
+		case "copyCurrentTabMarkdownUrl": {
 			if (currentTab) {
 				return copyMarkdownUrl(currentTab);
 			}
 
 			break;
+		}
 
-		case "openSettingsPage":
+		case "openSettingsPage": {
 			await browser.runtime.openOptionsPage();
 			break;
+		}
 
-		case "openPageInNewTab":
+		case "openPageInNewTab": {
 			await browser.tabs.create({ url: command.arg });
 			break;
+		}
 
-		case "refreshTabMarkers":
+		case "refreshTabMarkers": {
 			await refreshTabMarkers();
 			break;
+		}
 
-		case "focusOrCreateTabByUrl":
+		case "focusOrCreateTabByUrl": {
 			return focusOrCreateTabByUrl(command.arg);
+		}
 
-		case "focusTabByText":
+		case "focusTabByText": {
 			await focusTabByText(command.arg);
 			break;
+		}
 
-		case "cycleTabsByText":
+		case "cycleTabsByText": {
 			await cycleTabsByText(command.arg);
 			break;
+		}
 
-		default:
+		default: {
 			break;
+		}
 	}
 
 	return undefined;

--- a/src/background/hints/hintsAllocator.ts
+++ b/src/background/hints/hintsAllocator.ts
@@ -2,7 +2,7 @@ import { Mutex } from "async-mutex";
 import browser from "webextension-polyfill";
 import { getKeysToExclude } from "../../common/getKeysToExclude";
 import { retrieve, store } from "../../common/storage";
-import { HintsStack } from "../../typings/StorageSchema";
+import { type HintsStack } from "../../typings/StorageSchema";
 import { letterHints, numberHints } from "../../common/allHints";
 import { navigationOccurred } from "./preloadTabs";
 
@@ -17,8 +17,8 @@ async function getEmptyStack(tabId: number): Promise<HintsStack> {
 		useNumberHints && !keyboardClicking
 			? [...numberHints]
 			: includeSingleLetterHints && !keyboardClicking
-			? [...letterHints]
-			: letterHints.slice(0, -26);
+				? [...letterHints]
+				: letterHints.slice(0, -26);
 
 	// We filter out any hint the user has excluded or any hint that starts with
 	// an excluded key for the current url.
@@ -34,7 +34,7 @@ async function getEmptyStack(tabId: number): Promise<HintsStack> {
 			!hintsToExclude
 				.toLowerCase()
 				.split(/[, ]/)
-				.filter((string) => string)
+				.filter(Boolean)
 				.map((string) => string.trim())
 				.includes(hint)
 	);

--- a/src/background/hints/preloadTabs.ts
+++ b/src/background/hints/preloadTabs.ts
@@ -29,7 +29,7 @@ export async function preloadTabCompleted() {
 export async function navigationOccurred(tabId: number) {
 	const preloadTabDetails = preloadTabs.get(tabId);
 
-	if (!preloadTabDetails || !preloadTabDetails.completed) return false;
+	if (!preloadTabDetails?.completed) return false;
 
 	// I should be using browser.webNavigation.getFrame here but for whatever
 	// reason it's not working in Safari, although it is supposed to be supported.

--- a/src/background/messaging/handleRequestFromContent.ts
+++ b/src/background/messaging/handleRequestFromContent.ts
@@ -1,5 +1,5 @@
 import browser from "webextension-polyfill";
-import { RequestFromContent } from "../../typings/RequestFromContent";
+import { type RequestFromContent } from "../../typings/RequestFromContent";
 import { assertDefined } from "../../typings/TypingUtils";
 import {
 	claimHints,
@@ -33,7 +33,7 @@ export async function handleRequestFromContent(
 	const frameId = sender.frameId ?? 0;
 
 	switch (request.type) {
-		case "initStack":
+		case "initStack": {
 			// This is to be extra safe as we already make sure we are only sending
 			// this request from the main frame of the content script
 			if (frameId !== 0) {
@@ -44,45 +44,54 @@ export async function handleRequestFromContent(
 			}
 
 			return initStack(tabId);
+		}
 
-		case "claimHints":
+		case "claimHints": {
 			return claimHints(tabId, frameId, request.amount);
+		}
 
-		case "reclaimHintsFromOtherFrames":
+		case "reclaimHintsFromOtherFrames": {
 			return reclaimHintsFromOtherFrames(tabId, frameId, request.amount);
+		}
 
-		case "releaseHints":
+		case "releaseHints": {
 			return releaseHints(tabId, request.hints);
+		}
 
-		case "storeHintsInFrame":
+		case "storeHintsInFrame": {
 			return storeHintsInFrame(tabId, frameId, request.hints);
+		}
 
-		case "getHintsStackForTab":
+		case "getHintsStackForTab": {
 			return withStack(tabId, async (stack) => {
 				return stack;
 			});
+		}
 
-		case "openInNewTab":
+		case "openInNewTab": {
 			await openInNewTab([request.url], true);
 			break;
+		}
 
-		case "openInBackgroundTab":
+		case "openInBackgroundTab": {
 			await openInNewTab(request.links, false);
 
 			break;
+		}
 
 		case "getContentScriptContext": {
 			return { tabId, frameId, currentTabId };
 		}
 
-		case "clickHintInFrame":
+		case "clickHintInFrame": {
 			await sendRequestToContent({
 				type: "clickElement",
 				target: [request.hint],
 			});
 			break;
+		}
 
-		case "markHintsAsKeyboardReachable":
+		case "markHintsAsKeyboardReachable": {
 			await sendRequestToContent(
 				{
 					type: "markHintsAsKeyboardReachable",
@@ -91,8 +100,9 @@ export async function handleRequestFromContent(
 				tabId
 			);
 			break;
+		}
 
-		case "restoreKeyboardReachableHints":
+		case "restoreKeyboardReachableHints": {
 			await sendRequestToContent(
 				{
 					type: "restoreKeyboardReachableHints",
@@ -100,26 +110,33 @@ export async function handleRequestFromContent(
 				tabId
 			);
 			break;
+		}
 
-		case "isCurrentTab":
+		case "isCurrentTab": {
 			return isCurrentTab;
+		}
 
-		case "getTabMarker":
+		case "getTabMarker": {
 			return getTabMarker(tabId);
+		}
 
-		case "storeCustomSelectors":
+		case "storeCustomSelectors": {
 			await storeCustomSelectors(request.url, request.selectors);
 			break;
+		}
 
-		case "resetCustomSelectors":
+		case "resetCustomSelectors": {
 			return resetCustomSelectors(request.url);
+		}
 
-		case "removeReference":
+		case "removeReference": {
 			return removeReference(request.hostPattern, request.name);
+		}
 
-		default:
+		default: {
 			console.error(request);
 			throw new Error("Bad request to background script");
+		}
 	}
 
 	return undefined;

--- a/src/background/messaging/handleRequestFromTalon.ts
+++ b/src/background/messaging/handleRequestFromTalon.ts
@@ -1,6 +1,7 @@
+import process from "process";
 import { retrieve } from "../../common/storage";
 import { promiseWrap } from "../../lib/promiseWrap";
-import { RequestFromTalon } from "../../typings/RequestFromTalon";
+import { type RequestFromTalon } from "../../typings/RequestFromTalon";
 import { dispatchCommand } from "../commands/dispatchCommand";
 import {
 	getRequestFromClipboard,

--- a/src/background/messaging/sendRequestToContent.ts
+++ b/src/background/messaging/sendRequestToContent.ts
@@ -1,13 +1,13 @@
 import browser from "webextension-polyfill";
-import { RequestFromBackground } from "../../typings/RequestFromBackground";
-import { TalonAction } from "../../typings/RequestFromTalon";
+import { type RequestFromBackground } from "../../typings/RequestFromBackground";
+import { type TalonAction } from "../../typings/RequestFromTalon";
 import { isPromiseFulfilledResult } from "../../typings/TypingUtils";
 import { getCurrentTabId } from "../utils/getCurrentTab";
 import { splitRequestsByFrame } from "../utils/splitRequestsByFrame";
 import {
-	RangoActionRemoveReference,
-	RangoActionRunActionOnReference,
-	RangoActionWithTargets,
+	type RangoActionRemoveReference,
+	type RangoActionRunActionOnReference,
+	type RangoActionWithTargets,
 } from "../../typings/RangoAction";
 import { notify } from "../utils/notify";
 
@@ -164,7 +164,7 @@ export async function sendRequestToContent(
 				// talon "noHintFound" to type those letters
 				results.length === 1 &&
 				isPromiseFulfilledResult(results[0]!) &&
-				results[0]!.value
+				results[0].value
 			) {
 				return results[0].value as TalonAction;
 			}
@@ -189,7 +189,7 @@ export async function sendRequestToContent(
 		);
 	}
 
-	frameId = frameId ?? toAllFrames.has(request.type) ? undefined : 0;
+	frameId = (frameId ?? toAllFrames.has(request.type)) ? undefined : 0;
 	request.frameId = frameId;
 
 	return browser.tabs.sendMessage(targetTabId, request, {

--- a/src/background/misc/createContextMenus.ts
+++ b/src/background/misc/createContextMenus.ts
@@ -62,10 +62,9 @@ export async function contextMenusOnClicked({
 		const keysToExclude = await retrieve("keysToExclude");
 		const tab = await getCurrentTab();
 		const hostPattern = tab.url && getHostPattern(tab.url);
-		const keysToExcludeForHost =
-			(hostPattern &&
-				keysToExclude.find(([pattern]) => pattern === hostPattern)) ||
-			undefined;
+		const keysToExcludeForHost = keysToExclude.find(
+			([pattern]) => pattern === hostPattern
+		);
 
 		if (!keysToExcludeForHost && hostPattern) {
 			keysToExclude.push([hostPattern, ""]);

--- a/src/background/misc/tabMarkers.ts
+++ b/src/background/misc/tabMarkers.ts
@@ -1,7 +1,7 @@
 import browser from "webextension-polyfill";
 import { Mutex } from "async-mutex";
 import { retrieve, store } from "../../common/storage";
-import { TabMarkers } from "../../typings/StorageSchema";
+import { type TabMarkers } from "../../typings/StorageSchema";
 import { letterHints } from "../../common/allHints";
 import { sendRequestToContent } from "../messaging/sendRequestToContent";
 

--- a/src/background/setup/initBackgroundScript.ts
+++ b/src/background/setup/initBackgroundScript.ts
@@ -1,3 +1,4 @@
+import process from "process";
 import browser from "webextension-polyfill";
 import { retrieve, store } from "../../common/storage";
 import { urls } from "../../common/urls";
@@ -35,12 +36,12 @@ browser.runtime.onInstalled.addListener(async ({ reason, previousVersion }) => {
 		const [currentMajor, currentMinor] = currentVersion.split(".") as [
 			string,
 			string,
-			string
+			string,
 		];
 		const [previousMajor, previousMinor] = previousVersion!.split(".") as [
 			string,
 			string,
-			string
+			string,
 		];
 
 		if (currentMajor !== previousMajor || currentMinor !== previousMinor) {

--- a/src/background/setup/trackRecentTabs.ts
+++ b/src/background/setup/trackRecentTabs.ts
@@ -28,7 +28,7 @@ async function updateRecentTab(
 			tabsIds.splice(index, 1);
 		}
 
-		if (!remove && tabsIds[tabsIds.length - 1] !== tabId) {
+		if (!remove && tabsIds.at(-1) !== tabId) {
 			tabsIds.push(tabId);
 		}
 

--- a/src/background/utils/browserAction.ts
+++ b/src/background/utils/browserAction.ts
@@ -5,9 +5,7 @@ import { retrieve } from "../../common/storage";
 /**
  * `browser.browserAction` for MV2 and `browser.action` for MV3.
  */
-export const browserAction = browser.action
-	? browser.action
-	: browser.browserAction;
+export const browserAction = browser.action ?? browser.browserAction;
 
 /**
  * Set the browserAction icon depending on wether keyboardClicking is enabled.

--- a/src/background/utils/clipboard.ts
+++ b/src/background/utils/clipboard.ts
@@ -1,9 +1,8 @@
 import browser from "webextension-polyfill";
 import { urls } from "../../common/urls";
-
 import {
-	RequestFromTalon,
-	ResponseToTalon,
+	type RequestFromTalon,
+	type ResponseToTalon,
 } from "../../typings/RequestFromTalon";
 import { notify } from "./notify";
 import { isSafari } from "./isSafari";

--- a/src/background/utils/constructTalonResponse.ts
+++ b/src/background/utils/constructTalonResponse.ts
@@ -1,7 +1,7 @@
 import {
-	ResponseToTalon,
-	TalonAction,
-	TalonActionLegacy,
+	type ResponseToTalon,
+	type TalonAction,
+	type TalonActionLegacy,
 } from "../../typings/RequestFromTalon";
 
 export function constructTalonResponse(

--- a/src/background/utils/getCurrentTab.ts
+++ b/src/background/utils/getCurrentTab.ts
@@ -1,4 +1,4 @@
-import browser, { Tabs } from "webextension-polyfill";
+import browser, { type Tabs } from "webextension-polyfill";
 
 export async function getCurrentTab(): Promise<Tabs.Tab> {
 	const currentTabArray = await browser.tabs.query({

--- a/src/background/utils/notify.ts
+++ b/src/background/utils/notify.ts
@@ -1,5 +1,5 @@
 import browser from "webextension-polyfill";
-import { ToastOptions } from "react-toastify";
+import { type ToastOptions } from "react-toastify";
 import { urls } from "../../common/urls";
 import { retrieve } from "../../common/storage";
 import { getCurrentTabId } from "./getCurrentTab";

--- a/src/background/utils/offscreen.ts
+++ b/src/background/utils/offscreen.ts
@@ -1,13 +1,13 @@
-interface CopyToClipboardMessage {
+type CopyToClipboardMessage = {
 	type: "copy-to-clipboard";
 	target: "offscreen-doc";
 	text: string;
-}
+};
 
-interface ReadClipboardMessage {
+type ReadClipboardMessage = {
 	type: "read-clipboard";
 	target: "offscreen-doc";
-}
+};
 
 type OffscreenMessage = CopyToClipboardMessage | ReadClipboardMessage;
 
@@ -18,20 +18,23 @@ chrome.runtime.onMessage.addListener(
 		if (message.target !== "offscreen-doc") return;
 
 		switch (message.type) {
-			case "copy-to-clipboard":
+			case "copy-to-clipboard": {
 				textarea.value = message.text;
 				textarea.select();
 				document.execCommand("copy");
 				break;
+			}
 
-			case "read-clipboard":
+			case "read-clipboard": {
 				textarea.select();
 				document.execCommand("paste");
 				sendResponse(textarea.value);
 				return true;
+			}
 
-			default:
+			default: {
 				break;
+			}
 		}
 
 		return false;

--- a/src/background/utils/splitRequestsByFrame.ts
+++ b/src/background/utils/splitRequestsByFrame.ts
@@ -1,4 +1,4 @@
-import { RangoActionWithTarget, hasArg } from "../../typings/RangoAction";
+import { type RangoActionWithTarget } from "../../typings/RangoAction";
 import { withStack } from "../hints/hintsAllocator";
 
 /**
@@ -14,8 +14,8 @@ export async function splitRequestsByFrame(
 ): Promise<Map<number, RangoActionWithTarget> | undefined> {
 	const hints =
 		typeof request.target === "string" ? [request.target] : request.target;
-	const hintsByFrame: Map<number, string[]> = new Map();
-	const requests: Map<number, any> = new Map();
+	const hintsByFrame = new Map<number, string[]>();
+	const requests = new Map<number, any>();
 
 	return withStack(tabId, async (stack) => {
 		for (const hint of hints) {
@@ -33,7 +33,7 @@ export async function splitRequestsByFrame(
 		}
 
 		for (const [key, value] of hintsByFrame.entries()) {
-			const arg = hasArg(request) ? request.arg : undefined;
+			const arg = "arg" in request ? request.arg : undefined;
 
 			requests.set(key, {
 				type: request.type,

--- a/src/background/utils/storeCustomSelectors.ts
+++ b/src/background/utils/storeCustomSelectors.ts
@@ -1,6 +1,6 @@
 import assertNever from "assert-never";
 import { debounce } from "lodash";
-import { CustomSelector } from "../../typings/StorageSchema";
+import { type CustomSelector } from "../../typings/StorageSchema";
 import { notify } from "./notify";
 import { withLockedStorageAccess } from "./withLockedStorageValue";
 import { filterInPlace } from "./arrayUtils";

--- a/src/background/utils/tabUtils.ts
+++ b/src/background/utils/tabUtils.ts
@@ -1,4 +1,4 @@
-import browser from "webextension-polyfill";
+import type browser from "webextension-polyfill";
 import { getCurrentTab } from "./getCurrentTab";
 
 /**

--- a/src/background/utils/withLockedStorageValue.ts
+++ b/src/background/utils/withLockedStorageValue.ts
@@ -1,5 +1,5 @@
 import { Mutex } from "async-mutex";
-import { StorageSchema } from "../../typings/StorageSchema";
+import { type StorageSchema } from "../../typings/StorageSchema";
 import { retrieve, store } from "../../common/storage";
 
 const mutexes = new Map<keyof StorageSchema, Mutex>();

--- a/src/common/defaultStorage.ts
+++ b/src/common/defaultStorage.ts
@@ -1,4 +1,4 @@
-import { StorageSchema } from "../typings/StorageSchema";
+import { type StorageSchema } from "../typings/StorageSchema";
 import { letterHints } from "./allHints";
 import { defaultSettings } from "./settings";
 

--- a/src/common/getKeysToExclude.ts
+++ b/src/common/getKeysToExclude.ts
@@ -6,7 +6,7 @@ function stringToSet(keysString: string) {
 		keysString
 			.split(/[, ]/)
 			.map((string) => string.trim())
-			.filter((string) => string)
+			.filter(Boolean)
 	);
 }
 

--- a/src/common/selectorUtils.ts
+++ b/src/common/selectorUtils.ts
@@ -4,7 +4,8 @@ export function getSpecificityValue(selector: string) {
 	const { specificityArray } = calculate(selector)[0]!;
 
 	return (specificityArray as number[]).reduce(
-		(acc, curr, index, array) => acc + curr * 10 ** (array.length - index - 1)
+		(accumulator, current, index, array) =>
+			accumulator + current * 10 ** (array.length - index - 1)
 	);
 }
 

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -1,5 +1,8 @@
 import Color from "color";
-import { CustomSelector, StorageSchema } from "../typings/StorageSchema";
+import {
+	type CustomSelector,
+	type StorageSchema,
+} from "../typings/StorageSchema";
 
 export const defaultSettings = {
 	hintUppercaseLetters: false,
@@ -95,7 +98,7 @@ export function isValidSetting<T extends keyof StorageSchema>(
 	if (!isSetting(key)) return false;
 
 	const validator = validators[key];
-	if (typeof validator === "undefined") return true;
+	if (validator === undefined) return true;
 
 	return validator(value);
 }

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -1,10 +1,10 @@
 /* eslint-disable no-await-in-loop */
 import { Mutex } from "async-mutex";
 import browser from "webextension-polyfill";
-import { StorageSchema, zStorageSchema } from "../typings/StorageSchema";
+import { type StorageSchema, zStorageSchema } from "../typings/StorageSchema";
 import { defaultStorage } from "./defaultStorage";
 import {
-	Settings,
+	type Settings,
 	defaultSettings,
 	isSetting,
 	isValidSetting,
@@ -40,6 +40,7 @@ function reviver(_key: string, value: any) {
 		value.dataType === "Map" &&
 		value.value
 	) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		return new Map(value.value);
 	}
 
@@ -148,7 +149,7 @@ export async function retrieveSettings() {
 	let key: keyof Settings;
 
 	for (key in defaultSettings) {
-		if (Object.prototype.hasOwnProperty.call(defaultSettings, key)) {
+		if (Object.hasOwn(defaultSettings, key)) {
 			settings[key] = await retrieve(key);
 		}
 	}

--- a/src/common/transformSettings.ts
+++ b/src/common/transformSettings.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { CustomSelector, StorageSchema } from "../typings/StorageSchema";
+import {
+	type CustomSelector,
+	type StorageSchema,
+} from "../typings/StorageSchema";
 import { isValidSelector } from "./selectorUtils";
 import { isValidRegExp } from "./textUtils";
 
@@ -8,7 +11,7 @@ type CustomsSelectorsLegacyEntry = [
 	{
 		include: string[];
 		exclude: string[];
-	}
+	},
 ];
 
 /**
@@ -88,7 +91,7 @@ export function prepareSettingForStoring<T extends keyof StorageSchema>(
 	value: StorageSchema[T]
 ) {
 	switch (key) {
-		case "customSelectors":
+		case "customSelectors": {
 			return (
 				(value as StorageSchema["customSelectors"])
 					.filter(
@@ -104,11 +107,16 @@ export function prepareSettingForStoring<T extends keyof StorageSchema>(
 							(a.type === "include" ? -1 : 1)
 					) as StorageSchema[T]
 			);
-		case "keysToExclude":
+		}
+
+		case "keysToExclude": {
 			return (value as StorageSchema["keysToExclude"]).filter(
 				([pattern]) => pattern
 			) as StorageSchema[T];
-		default:
+		}
+
+		default: {
 			return value;
+		}
 	}
 }

--- a/src/content/actions/clickElement.ts
+++ b/src/content/actions/clickElement.ts
@@ -1,5 +1,5 @@
-import { ElementWrapper } from "../../typings/ElementWrapper";
-import { TalonAction } from "../../typings/RequestFromTalon";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
+import { type TalonAction } from "../../typings/RequestFromTalon";
 import { openInBackgroundTab } from "./openInNewTab";
 
 export async function clickElement(

--- a/src/content/actions/copy.ts
+++ b/src/content/actions/copy.ts
@@ -1,4 +1,4 @@
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { hasPropertyValue } from "../../typings/TypingUtils";
 import { showTooltip } from "../hints/showTooltip";
 

--- a/src/content/actions/customHints.ts
+++ b/src/content/actions/customHints.ts
@@ -1,5 +1,5 @@
 import browser from "webextension-polyfill";
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import {
 	saveCustomSelectors,
 	stageCustomSelectors,

--- a/src/content/actions/focus.ts
+++ b/src/content/actions/focus.ts
@@ -1,8 +1,8 @@
-import { TalonAction } from "../../typings/RequestFromTalon";
+import { type TalonAction } from "../../typings/RequestFromTalon";
 import { notify } from "../notify/notify";
 import { dispatchKeyDown, dispatchKeyUp } from "../utils/dispatchEvents";
 import { editableElementSelector, getFocusable } from "../utils/domUtils";
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { getOrCreateWrapper } from "../wrappers/ElementWrapperClass";
 
 export function focus(wrappers: ElementWrapper[]): TalonAction[] | undefined {

--- a/src/content/actions/focusAndDeleteContents.ts
+++ b/src/content/actions/focusAndDeleteContents.ts
@@ -1,5 +1,5 @@
-import { ElementWrapper } from "../../typings/ElementWrapper";
-import { TalonAction } from "../../typings/RequestFromTalon";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
+import { type TalonAction } from "../../typings/RequestFromTalon";
 import { isEditable } from "../utils/domUtils";
 
 export function focusAndDeleteContents(

--- a/src/content/actions/hoverElement.ts
+++ b/src/content/actions/hoverElement.ts
@@ -1,4 +1,4 @@
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { getHintedWrappers } from "../wrappers/wrappers";
 
 export async function hoverElement(wrappers: ElementWrapper[]) {

--- a/src/content/actions/insertToField.ts
+++ b/src/content/actions/insertToField.ts
@@ -1,4 +1,4 @@
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { hasPropertyValue } from "../../typings/TypingUtils";
 import { setSelectionAfter } from "./setSelection";
 
@@ -12,7 +12,7 @@ export async function insertToField(wrappers: ElementWrapper[], text: string) {
 		}
 	}
 
-	const lastWrapper = wrappers[wrappers.length - 1]!;
+	const lastWrapper = wrappers.at(-1)!;
 	await setSelectionAfter(lastWrapper);
 	if (lastWrapper.element instanceof HTMLElement) {
 		lastWrapper.element.focus();

--- a/src/content/actions/keyboardClicking.ts
+++ b/src/content/actions/keyboardClicking.ts
@@ -10,8 +10,8 @@ let keysPressedBuffer = "";
 let timeoutId: ReturnType<typeof setTimeout>;
 
 export function markHintsAsKeyboardReachable(letter: string) {
-	const wrappers = getHintedWrappers().filter(
-		(wrapper) => wrapper.hint?.string && wrapper.hint.string.startsWith(letter)
+	const wrappers = getHintedWrappers().filter((wrapper) =>
+		wrapper.hint?.string?.startsWith(letter)
 	);
 	for (const wrapper of wrappers) {
 		wrapper?.hint?.keyHighlight();

--- a/src/content/actions/openInNewTab.ts
+++ b/src/content/actions/openInNewTab.ts
@@ -1,5 +1,5 @@
 import browser from "webextension-polyfill";
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { assertDefined } from "../../typings/TypingUtils";
 
 export async function openInNewTab(wrappers: ElementWrapper[]) {

--- a/src/content/actions/references.ts
+++ b/src/content/actions/references.ts
@@ -1,7 +1,7 @@
 import browser from "webextension-polyfill";
 import { getCssSelector } from "css-selector-generator";
 import { store } from "../../common/storage";
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { showTooltip } from "../hints/showTooltip";
 import { getOrCreateWrapper } from "../wrappers/ElementWrapperClass";
 import { getHostPattern } from "../../common/utils";

--- a/src/content/actions/runActionOnReference.ts
+++ b/src/content/actions/runActionOnReference.ts
@@ -1,5 +1,5 @@
 import { promiseWrap } from "../../lib/promiseWrap";
-import { RangoActionWithTargets } from "../../typings/RangoAction";
+import { type RangoActionWithTargets } from "../../typings/RangoAction";
 import { getOrCreateWrapper } from "../wrappers/ElementWrapperClass";
 import { getLastWrapper } from "../wrappers/lastWrapper";
 import { getReferences } from "./references";
@@ -19,9 +19,9 @@ function findClosestElement(
 		// Calculate the distance between the top left points of the elements. We
 		// could calculate the distance between the center points but this is
 		// simpler and I think it's enough.
-		const distance = Math.sqrt(
-			(currentRect.left - targetRect.left) ** 2 +
-				(currentRect.top - targetRect.top) ** 2
+		const distance = Math.hypot(
+			currentRect.left - targetRect.left,
+			currentRect.top - targetRect.top
 		);
 
 		if (distance < minDistance) {
@@ -50,7 +50,7 @@ async function getElementFromSelector(selector: string, maxWait: number) {
 		}
 
 		const timeout = setTimeout(() => {
-			reject();
+			reject(new Error("Timed out waiting for element matching selector."));
 		}, maxWait);
 
 		const observer = new MutationObserver(() => {

--- a/src/content/actions/runActionOnTextMatchedElement.ts
+++ b/src/content/actions/runActionOnTextMatchedElement.ts
@@ -1,5 +1,5 @@
 import Fuse from "fuse.js";
-import { RangoActionWithTargets } from "../../typings/RangoAction";
+import { type RangoActionWithTargets } from "../../typings/RangoAction";
 import { getSetting } from "../settings/settingsManager";
 import { getToggles } from "../settings/toggles";
 import { deepGetElements } from "../utils/deepGetElements";
@@ -91,7 +91,7 @@ export async function matchElementByText(
 				}
 
 				return a.score! - b.score!;
-		  })
+			})
 		: matches;
 
 	const bestMatch = sortedMatches[0];

--- a/src/content/actions/runRangoActionWithTarget.ts
+++ b/src/content/actions/runRangoActionWithTarget.ts
@@ -1,9 +1,9 @@
-import { RangoActionWithTarget } from "../../typings/RangoAction";
+import { type RangoActionWithTarget } from "../../typings/RangoAction";
 import { assertDefined } from "../../typings/TypingUtils";
 import { getWrapper, getWrapperForElement } from "../wrappers/wrappers";
-import { TalonAction } from "../../typings/RequestFromTalon";
+import { type TalonAction } from "../../typings/RequestFromTalon";
 import { activateEditable } from "../utils/activateEditable";
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { notify } from "../notify/notify";
 import { setLastWrapper } from "../wrappers/lastWrapper";
 import { clickElement } from "./clickElement";
@@ -66,8 +66,9 @@ export async function runRangoActionWithTarget(
 	setLastWrapper(wrapper);
 	switch (request.type) {
 		case "clickElement":
-		case "directClickElement":
+		case "directClickElement": {
 			return clickElement(wrappers);
+		}
 
 		case "tryToFocusElementAndCheckIsEditable": {
 			// This might result in a Talon time out exception if tryToFocusOnEditable
@@ -76,109 +77,133 @@ export async function runRangoActionWithTarget(
 			return [{ name: "responseValue", value: Boolean(activeEditable) }];
 		}
 
-		case "focusElement":
+		case "focusElement": {
 			return focus(wrappers);
+		}
 
-		case "showLink":
+		case "showLink": {
 			showTitleAndHref(wrappers);
 			break;
+		}
 
-		case "openInNewTab":
+		case "openInNewTab": {
 			await openInNewTab(wrappers);
 			break;
+		}
 
-		case "openInBackgroundTab":
+		case "openInBackgroundTab": {
 			await openInBackgroundTab(wrappers);
 			break;
+		}
 
-		case "hoverElement":
+		case "hoverElement": {
 			await hoverElement(wrappers);
 			break;
+		}
 
-		case "copyLink":
+		case "copyLink": {
 			return copyLinkToClipboard(wrappers);
+		}
 
-		case "copyMarkdownLink":
+		case "copyMarkdownLink": {
 			return copyMarkdownLinkToClipboard(wrappers);
+		}
 
-		case "copyElementTextContent":
+		case "copyElementTextContent": {
 			return copyElementTextContentToClipboard(wrappers);
+		}
 
 		// This is not used anymore. I leave it here for now for backwards
 		// compatibility - 2023-06-02
-		case "insertToField":
+		case "insertToField": {
 			await insertToField(wrappers, request.arg);
 			break;
+		}
 
-		case "setSelectionBefore":
+		case "setSelectionBefore": {
 			// This might result in a Talon time out exception if setSelectionBefofre
 			// causes a navigation, as the current content script is stopped.
 			await setSelectionBefore(wrapper);
 			break;
+		}
 
-		case "setSelectionAfter":
+		case "setSelectionAfter": {
 			// This might result in a Talon time out exception if setSelectionAfter
 			// causes a navigation, as the current content script is stopped.
 			await setSelectionAfter(wrapper);
 			break;
+		}
 
 		// This is not used anymore. I leave it here for now for backwards
 		// compatibility - 2023-06-02
-		case "focusAndDeleteContents":
+		case "focusAndDeleteContents": {
 			return focusAndDeleteContents(wrapper);
+		}
 
-		case "scrollUpAtElement":
+		case "scrollUpAtElement": {
 			scroll({ dir: "up", target: wrapper, factor: request.arg });
 			break;
+		}
 
-		case "scrollDownAtElement":
+		case "scrollDownAtElement": {
 			scroll({ dir: "down", target: wrapper, factor: request.arg });
 			break;
+		}
 
-		case "scrollLeftAtElement":
+		case "scrollLeftAtElement": {
 			scroll({ dir: "left", target: wrapper, factor: request.arg });
 			break;
+		}
 
-		case "scrollRightAtElement":
+		case "scrollRightAtElement": {
 			scroll({ dir: "right", target: wrapper, factor: request.arg });
 			break;
+		}
 
-		case "scrollElementToTop":
+		case "scrollElementToTop": {
 			snapScroll("top", wrapper);
 			break;
+		}
 
-		case "scrollElementToBottom":
+		case "scrollElementToBottom": {
 			snapScroll("bottom", wrapper);
 			break;
+		}
 
-		case "scrollElementToCenter":
+		case "scrollElementToCenter": {
 			snapScroll("center", wrapper);
 			break;
+		}
 
-		case "includeExtraSelectors":
+		case "includeExtraSelectors": {
 			await markHintsForInclusion(wrappers);
 			break;
+		}
 
-		case "excludeExtraSelectors":
+		case "excludeExtraSelectors": {
 			await markHintsForExclusion(wrappers);
 			break;
+		}
 
-		case "saveReference":
+		case "saveReference": {
 			await saveReference(wrapper, request.arg);
 			break;
+		}
 
-		case "hideHint":
+		case "hideHint": {
 			for (const wrapper of wrappers) {
 				wrapper.hint?.hide();
 			}
 
 			break;
+		}
 
-		default:
+		default: {
 			await notify(`Invalid action "${request.type}"`, {
 				type: "error",
 			});
 			break;
+		}
 	}
 
 	return undefined;

--- a/src/content/actions/runRangoActionWithoutTarget.ts
+++ b/src/content/actions/runRangoActionWithoutTarget.ts
@@ -1,5 +1,5 @@
 import { toast } from "react-toastify";
-import { RangoActionWithoutTarget } from "../../typings/RangoAction";
+import { type RangoActionWithoutTarget } from "../../typings/RangoAction";
 import { notify, notifyTogglesStatus } from "../notify/notify";
 import { isEditable } from "../utils/domUtils";
 import {
@@ -31,166 +31,204 @@ export async function runRangoActionWithoutTarget(
 	request: RangoActionWithoutTarget
 ): Promise<string | number | boolean | undefined> {
 	switch (request.type) {
-		case "historyGoBack":
+		case "historyGoBack": {
 			window.history.back();
 			break;
+		}
 
-		case "historyGoForward":
+		case "historyGoForward": {
 			window.history.forward();
 			break;
+		}
 
-		case "navigateToPageRoot":
+		case "navigateToPageRoot": {
 			window.location.href = "/";
 			break;
+		}
 
-		case "navigateToNextPage":
+		case "navigateToNextPage": {
 			navigateToNextPage();
 			break;
+		}
 
-		case "navigateToPreviousPage":
+		case "navigateToPreviousPage": {
 			navigateToPreviousPage();
 			break;
+		}
 
-		case "displayTogglesStatus":
+		case "displayTogglesStatus": {
 			await notifyTogglesStatus(true);
 			break;
+		}
 
-		case "focusFirstInput":
+		case "focusFirstInput": {
 			await focusFirstInput();
 			break;
+		}
 
-		case "scrollUpPage":
+		case "scrollUpPage": {
 			scroll({ dir: "up", target: "page", factor: request.arg });
 			break;
+		}
 
-		case "scrollDownPage":
+		case "scrollDownPage": {
 			scroll({ dir: "down", target: "page", factor: request.arg });
 			break;
+		}
 
-		case "scrollUpLeftAside":
+		case "scrollUpLeftAside": {
 			scroll({ dir: "up", target: "leftAside", factor: request.arg });
 			break;
+		}
 
-		case "scrollDownLeftAside":
+		case "scrollDownLeftAside": {
 			scroll({ dir: "down", target: "leftAside", factor: request.arg });
 			break;
+		}
 
-		case "scrollUpRightAside":
+		case "scrollUpRightAside": {
 			scroll({ dir: "up", target: "rightAside", factor: request.arg });
 			break;
+		}
 
-		case "scrollDownRightAside":
+		case "scrollDownRightAside": {
 			scroll({ dir: "down", target: "rightAside", factor: request.arg });
 			break;
+		}
 
-		case "scrollLeftPage":
+		case "scrollLeftPage": {
 			scroll({ dir: "left", target: "page", factor: request.arg });
 			break;
+		}
 
-		case "scrollRightPage":
+		case "scrollRightPage": {
 			scroll({ dir: "right", target: "page", factor: request.arg });
 			break;
+		}
 
-		case "scrollUpAtElement":
+		case "scrollUpAtElement": {
 			scroll({ dir: "up", target: "repeatLast" });
 			break;
+		}
 
-		case "scrollDownAtElement":
+		case "scrollDownAtElement": {
 			scroll({ dir: "down", target: "repeatLast" });
 			break;
+		}
 
-		case "scrollRightAtElement":
+		case "scrollRightAtElement": {
 			scroll({ dir: "right", target: "repeatLast" });
 			break;
+		}
 
-		case "scrollLeftAtElement":
+		case "scrollLeftAtElement": {
 			scroll({ dir: "left", target: "repeatLast" });
 			break;
+		}
 
-		case "storeScrollPosition":
+		case "storeScrollPosition": {
 			await storeScrollPosition(request.arg);
 			break;
+		}
 
-		case "scrollToPosition":
+		case "scrollToPosition": {
 			await scrollToPosition(request.arg);
 			break;
+		}
 
-		case "displayExtraHints":
+		case "displayExtraHints": {
 			await displayMoreOrLessHints({ extra: true });
 			break;
+		}
 
-		case "displayExcludedHints":
+		case "displayExcludedHints": {
 			await displayMoreOrLessHints({ excluded: true });
 			break;
+		}
 
-		case "displayLessHints":
+		case "displayLessHints": {
 			await displayMoreOrLessHints({ extra: false, excluded: false });
 			break;
+		}
 
-		case "confirmSelectorsCustomization":
+		case "confirmSelectorsCustomization": {
 			await customHintsConfirm();
 			break;
+		}
 
 		case "resetCustomSelectors": {
 			await customHintsReset();
 			break;
 		}
 
-		case "includeOrExcludeMoreSelectors":
+		case "includeOrExcludeMoreSelectors": {
 			await markHintsWithBroaderSelector();
 			break;
+		}
 
-		case "includeOrExcludeLessSelectors":
+		case "includeOrExcludeLessSelectors": {
 			await markHintsWithNarrowerSelector();
 			break;
+		}
 
-		case "excludeAllHints":
+		case "excludeAllHints": {
 			await markAllHintsForExclusion();
 			break;
+		}
 
-		case "refreshHints":
+		case "refreshHints": {
 			await refreshHints();
 			break;
+		}
 
-		case "unhoverAll":
+		case "unhoverAll": {
 			blur();
 			unhoverAll();
 			toast.dismiss();
 			break;
+		}
 
-		case "checkActiveElementIsEditable":
+		case "checkActiveElementIsEditable": {
 			return Boolean(
 				document.hasFocus() &&
 					document.activeElement &&
 					isEditable(document.activeElement)
 			);
+		}
 
-		case "saveReferenceForActiveElement":
+		case "saveReferenceForActiveElement": {
 			await saveReferenceForActiveElement(request.arg);
 			break;
+		}
 
-		case "runActionOnReference":
+		case "runActionOnReference": {
 			return runActionOnReference(request.arg, request.arg2);
+		}
 
-		case "showReferences":
+		case "showReferences": {
 			await showReferences();
 			break;
+		}
 
-		case "removeReference":
+		case "removeReference": {
 			return removeReference(request.arg);
+		}
 
-		case "matchElementByText":
+		case "matchElementByText": {
 			return matchElementByText(request.text, request.prioritizeViewport);
+		}
 
-		case "executeActionOnTextMatchedElement":
+		case "executeActionOnTextMatchedElement": {
 			await executeActionOnTextMatchedElement(request.actionType);
 			break;
+		}
 
-		default:
+		default: {
 			await notify(`Invalid action "${request.type}"`, {
 				type: "error",
 			});
 			break;
+		}
 	}
 
 	return undefined;

--- a/src/content/actions/scroll.ts
+++ b/src/content/actions/scroll.ts
@@ -1,18 +1,19 @@
+import process from "process";
 import { isHtmlElement } from "../../typings/TypingUtils";
 import { getUserScrollableContainer } from "../utils/getUserScrollableContainer";
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { getSetting } from "../settings/settingsManager";
 
-const DEFAULT_SCROLL_FACTOR = 0.66;
+const defaultScrollFactor = 0.66;
 
 let lastScrollContainer: Element | undefined;
 let lastScrollFactor: number;
 
-interface ScrollOptions {
+type ScrollOptions = {
 	dir: "up" | "down" | "left" | "right";
 	target: ElementWrapper | "page" | "leftAside" | "rightAside" | "repeatLast";
 	factor?: number;
-}
+};
 
 export function getScrollBehavior() {
 	// Scroll tests fail if behavior is "smooth"
@@ -349,7 +350,7 @@ export function scroll(options: ScrollOptions) {
 
 	let left = 0;
 	let top = 0;
-	factor ??= DEFAULT_SCROLL_FACTOR;
+	factor ??= defaultScrollFactor;
 
 	// We store the values for future use
 	lastScrollContainer = scrollContainer;

--- a/src/content/actions/setSelection.ts
+++ b/src/content/actions/setSelection.ts
@@ -1,4 +1,4 @@
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { assertDefined } from "../../typings/TypingUtils";
 import { findFirstTextNode, findLastTextNode } from "../utils/nodeUtils";
 import { activateEditable } from "../utils/activateEditable";

--- a/src/content/actions/showTitleAndHref.ts
+++ b/src/content/actions/showTitleAndHref.ts
@@ -1,4 +1,4 @@
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { showTooltip } from "../hints/showTooltip";
 
 export function showTitleAndHref(wrappers: ElementWrapper[]) {

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,8 +1,8 @@
 import browser from "webextension-polyfill";
 // eslint-disable-next-line import/no-unassigned-import
 import "requestidlecallback-polyfill";
-import { RequestFromBackground } from "../typings/RequestFromBackground";
-import { TalonAction } from "../typings/RequestFromTalon";
+import { type RequestFromBackground } from "../typings/RequestFromBackground";
+import { type TalonAction } from "../typings/RequestFromTalon";
 import {
 	markHintsAsKeyboardReachable,
 	restoreKeyboardReachableHints,
@@ -51,13 +51,15 @@ browser.runtime.onMessage.addListener(
 		try {
 			switch (request.type) {
 				// SCRIPT REQUESTS
-				case "onCompleted":
+				case "onCompleted": {
 					await synchronizeHints();
 					break;
+				}
 
-				case "displayToastNotification":
+				case "displayToastNotification": {
 					await notify(request.text, request.options);
 					break;
+				}
 
 				case "reclaimHints": {
 					const reclaimed = reclaimHintsFromCache(request.amount);
@@ -69,45 +71,55 @@ browser.runtime.onMessage.addListener(
 					return reclaimed;
 				}
 
-				case "updateHintsInTab":
+				case "updateHintsInTab": {
 					updateHintsInTab(request.hints);
 					break;
+				}
 
-				case "markHintsAsKeyboardReachable":
+				case "markHintsAsKeyboardReachable": {
 					markHintsAsKeyboardReachable(request.letter);
 					break;
+				}
 
-				case "restoreKeyboardReachableHints":
+				case "restoreKeyboardReachableHints": {
 					restoreKeyboardReachableHints();
 					break;
+				}
 
-				case "checkIfDocumentHasFocus":
+				case "checkIfDocumentHasFocus": {
 					return document.hasFocus();
+				}
 
-				case "checkContentScriptRunning":
+				case "checkContentScriptRunning": {
 					return true;
+				}
 
-				case "updateNavigationToggle":
+				case "updateNavigationToggle": {
 					setNavigationToggle(request.enable);
 					await updateHintsEnabled();
 					await notifyTogglesStatus();
 					break;
+				}
 
-				case "allowToastNotification":
+				case "allowToastNotification": {
 					allowToastNotification();
 					break;
+				}
 
-				case "tryToFocusPage":
+				case "tryToFocusPage": {
 					window.focus();
 					break;
+				}
 
-				case "getTitleBeforeDecoration":
+				case "getTitleBeforeDecoration": {
 					return getTitleBeforeDecoration();
+				}
 
-				case "refreshTitleDecorations":
+				case "refreshTitleDecorations": {
 					removeDecorations();
 					await initTitleDecoration();
 					break;
+				}
 
 				default: {
 					const result = await runRangoActionWithoutTarget(request);

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -17,7 +17,7 @@ import {
 	notify,
 	notifyTogglesStatus,
 } from "./notify/notify";
-import { initContentScript } from "./setup/initContentScript";
+import { initContentScriptOrWait } from "./setup/initContentScript";
 import { setNavigationToggle } from "./settings/toggles";
 import { updateHintsEnabled } from "./observe";
 import { getFrameId } from "./setup/contentScriptContext";
@@ -42,6 +42,7 @@ browser.runtime.onMessage.addListener(
 	): Promise<
 		string | number | string[] | TalonAction[] | boolean | undefined
 	> => {
+		await initContentScriptOrWait();
 		if (await isWrongFrame(request)) return;
 
 		if ("target" in request) {
@@ -136,7 +137,7 @@ browser.runtime.onMessage.addListener(
 
 (async () => {
 	try {
-		await initContentScript();
+		await initContentScriptOrWait();
 	} catch (error: unknown) {
 		console.error(error);
 	}

--- a/src/content/hints/computeCustomSelectors.ts
+++ b/src/content/hints/computeCustomSelectors.ts
@@ -6,7 +6,7 @@ import {
 	isValidSelector,
 	selectorToArray,
 } from "../../common/selectorUtils";
-import { SelectorAlternative } from "../../typings/SelectorAlternative";
+import { type SelectorAlternative } from "../../typings/SelectorAlternative";
 
 function getChildNumber(target: Element) {
 	if (!target.parentElement) return undefined;
@@ -115,10 +115,10 @@ function getCommonSelectors(targets: Element[]) {
 		getSignificantSelectors(element)
 	);
 
-	const targetSelectors: Set<string> = new Set();
+	const targetSelectors = new Set<string>();
 
 	for (const list of selectorLists) {
-		const targetSelector = list[list.length - 1];
+		const targetSelector = list.at(-1);
 		if (targetSelector) targetSelectors.add(targetSelector);
 	}
 
@@ -214,13 +214,11 @@ export function getSelectorAlternatives(elements: Element[]) {
 		}
 
 		// If no element match the selector the elements are shadow dom elements
-		if (!amountOfElementsMatching) {
-			amountOfElementsMatching = deepGetElements(
-				document.body,
-				false,
-				selector
-			).length;
-		}
+		amountOfElementsMatching ||= deepGetElements(
+			document.body,
+			false,
+			selector
+		).length;
 
 		const specificityValue = getSpecificityValue(selector);
 

--- a/src/content/hints/customSelectorsStaging.ts
+++ b/src/content/hints/customSelectorsStaging.ts
@@ -1,8 +1,8 @@
 import browser from "webextension-polyfill";
 import { getHostPattern } from "../../common/utils";
-import { ElementWrapper } from "../../typings/ElementWrapper";
-import { SelectorAlternative } from "../../typings/SelectorAlternative";
-import { CustomSelector } from "../../typings/StorageSchema";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
+import { type SelectorAlternative } from "../../typings/SelectorAlternative";
+import { type CustomSelector } from "../../typings/StorageSchema";
 import { getSelectorAlternatives } from "./computeCustomSelectors";
 import { updateCustomSelectors } from "./selectors";
 

--- a/src/content/hints/getContextForHint.ts
+++ b/src/content/hints/getContextForHint.ts
@@ -6,16 +6,10 @@ import {
 	getFirstCharacterRect,
 } from "./layoutCache";
 
-declare global {
-	interface CSSStyleDeclaration {
-		contentVisibility: string;
-	}
-}
-
 // Minimum space that needs to be available so that we can place the hint in the
 // current element
-const ENOUGH_LEFT = 15;
-const ENOUGH_TOP = 10;
+const enoughLeft = 15;
+const enoughTop = 10;
 
 function getPaddingRect(element: Element): DOMRect {
 	const {
@@ -193,12 +187,12 @@ export function getAptContainer(origin: Element) {
 	return document.body;
 }
 
-interface HintContext {
+type HintContext = {
 	container: HTMLElement | ShadowRoot;
 	limitParent: HTMLElement;
 	availableSpaceLeft?: number;
 	availableSpaceTop?: number;
-}
+};
 
 export function getContextForHint(
 	element: Element,
@@ -305,7 +299,7 @@ export function getContextForHint(
 		previousSpaceLeft ??= spaceLeft;
 		previousSpaceTop ??= spaceTop;
 
-		if (spaceLeft > ENOUGH_LEFT && spaceTop > ENOUGH_TOP) {
+		if (spaceLeft > enoughLeft && spaceTop > enoughTop) {
 			// For example, with the following clipAncestors:
 			// clipAncestor[n]: (spaceLeft, spaceTop)
 			// -----------------------
@@ -320,8 +314,8 @@ export function getContextForHint(
 			container =
 				spaceLeft > previousSpaceLeft || spaceTop > previousSpaceTop
 					? // We know there's got to be a previousClipAncestor as for
-					  // clipAncestor[0] the spaces and candidate spaces are the same
-					  getAptContainer(previousClipAncestor!)
+						// clipAncestor[0] the spaces and candidate spaces are the same
+						getAptContainer(previousClipAncestor!)
 					: candidate;
 
 			previousSpaceLeft = spaceLeft;
@@ -334,8 +328,8 @@ export function getContextForHint(
 		// Once we have enough space in that direction there is no need to change
 		// the candidate
 		if (
-			(spaceLeft > previousSpaceLeft && previousSpaceLeft < ENOUGH_LEFT) ||
-			(spaceTop > previousSpaceTop && previousSpaceTop < ENOUGH_TOP)
+			(spaceLeft > previousSpaceLeft && previousSpaceLeft < enoughLeft) ||
+			(spaceTop > previousSpaceTop && previousSpaceTop < enoughTop)
 		) {
 			// We know there's got to be a previousClipAncestor as for
 			// clipAncestor[0] the spaces and previous spaces are the same

--- a/src/content/hints/getElementToPositionHint.ts
+++ b/src/content/hints/getElementToPositionHint.ts
@@ -13,12 +13,6 @@ import {
 	getFirstCharacterRect,
 } from "./layoutCache";
 
-declare global {
-	interface CSSStyleDeclaration {
-		maskImage: string;
-	}
-}
-
 function elementsAreNear(a: Element, b: Element) {
 	const aRect = getBoundingClientRect(a);
 	const bRect = getBoundingClientRect(b);

--- a/src/content/hints/hintsRequests.ts
+++ b/src/content/hints/hintsRequests.ts
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill";
 import { Mutex } from "async-mutex";
-import { HintsStack } from "../../typings/StorageSchema";
+import { type HintsStack } from "../../typings/StorageSchema";
 import {
 	addHintsInFrame,
 	clearHintsInFrame,

--- a/src/content/hints/layoutCache.ts
+++ b/src/content/hints/layoutCache.ts
@@ -1,10 +1,10 @@
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 
-const boundingClientRects: Map<Element, DOMRect> = new Map();
-const offsetParents: Map<Element, Element | null> = new Map();
-const firstCharacterRects: Map<Text, DOMRect> = new Map();
-const textRects: Map<Text, DOMRect> = new Map();
-const clientDimensions: Map<
+const boundingClientRects = new Map<Element, DOMRect>();
+const offsetParents = new Map<Element, Element | null>();
+const firstCharacterRects = new Map<Text, DOMRect>();
+const textRects = new Map<Text, DOMRect>();
+const clientDimensions = new Map<
 	Element,
 	{
 		clientWidth: number;
@@ -14,8 +14,8 @@ const clientDimensions: Map<
 		offsetWidth?: number;
 		offsetHeight?: number;
 	}
-> = new Map();
-const styles: Map<Element, CSSStyleDeclaration> = new Map();
+>();
+const styles = new Map<Element, CSSStyleDeclaration>();
 
 export function clearLayoutCache() {
 	boundingClientRects.clear();
@@ -100,9 +100,9 @@ export function cacheLayout(
 	const elements = isElementWrapperArray(targets)
 		? targets.map((wrapper) => wrapper.element)
 		: targets;
-	const toCache: Set<Element> = new Set();
+	const toCache = new Set<Element>();
 
-	const firstTextNodes: Map<Element, Text[]> = new Map();
+	const firstTextNodes = new Map<Element, Text[]>();
 
 	for (const element of elements) {
 		if (element instanceof Element && includeTextRect) {
@@ -179,11 +179,11 @@ export function getClientDimensions(element: Element) {
 
 	const offsetWidth =
 		element instanceof HTMLElement
-			? clientDimensions.get(element)?.offsetWidth ?? element.offsetWidth
+			? (clientDimensions.get(element)?.offsetWidth ?? element.offsetWidth)
 			: undefined;
 	const offsetHeight =
 		element instanceof HTMLElement
-			? clientDimensions.get(element)?.offsetHeight ?? element.offsetHeight
+			? (clientDimensions.get(element)?.offsetHeight ?? element.offsetHeight)
 			: undefined;
 
 	return {

--- a/src/content/hints/showTooltip.ts
+++ b/src/content/hints/showTooltip.ts
@@ -1,5 +1,5 @@
 import tippy from "tippy.js";
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { setStyleProperties } from "./setStyleProperties";
 
 export function showTooltip(
@@ -39,7 +39,7 @@ export function showTooltip(
 		zIndex: 2_147_483_647,
 		appendTo: tooltipAnchor,
 		maxWidth: "none",
-		allowHTML: true,
+		allowHTML: true, // eslint-disable-line @typescript-eslint/naming-convention
 	});
 
 	function handleScroll(event: Event) {

--- a/src/content/notify/Toast.tsx
+++ b/src/content/notify/Toast.tsx
@@ -1,7 +1,7 @@
-import "react-toastify/dist/ReactToastify.css";
 import { Bounce, Flip, Slide, ToastContainer, Zoom } from "react-toastify";
-import "./Toast.css";
+import "react-toastify/dist/ReactToastify.css";
 import { getSetting } from "../settings/settingsManager";
+import "./Toast.css";
 
 const transitions = {
 	slide: Slide,

--- a/src/content/notify/ToastIcon.tsx
+++ b/src/content/notify/ToastIcon.tsx
@@ -22,7 +22,7 @@ const icons = {
 };
 
 type ToastIconProps = {
-	iconType: keyof typeof icons;
+	readonly iconType: keyof typeof icons;
 };
 
 export function ToastIcon({ iconType }: ToastIconProps) {

--- a/src/content/notify/ToastMessage.tsx
+++ b/src/content/notify/ToastMessage.tsx
@@ -1,5 +1,5 @@
 type ToastMessageProps = {
-	children: React.ReactNode;
+	readonly children: React.ReactNode;
 };
 
 export function ToastMessage({ children }: ToastMessageProps) {

--- a/src/content/notify/ToastTogglesMessage.tsx
+++ b/src/content/notify/ToastTogglesMessage.tsx
@@ -9,8 +9,8 @@ function getIconType(value: boolean | undefined) {
 }
 
 type ToggleStatusProps = {
-	label: string;
-	status: boolean | undefined;
+	readonly label: string;
+	readonly status: boolean | undefined;
 };
 
 function ToggleStatus({ label, status }: ToggleStatusProps) {

--- a/src/content/notify/notify.tsx
+++ b/src/content/notify/notify.tsx
@@ -1,5 +1,5 @@
 import { createRoot } from "react-dom/client";
-import { ToastOptions, toast } from "react-toastify";
+import { type ToastOptions, toast } from "react-toastify";
 import { getSetting } from "../settings/settingsManager";
 import { isCurrentTab, isMainframe } from "../setup/contentScriptContext";
 import { Toast } from "./Toast";

--- a/src/content/settings/settingsManager.ts
+++ b/src/content/settings/settingsManager.ts
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill";
 import Emittery from "emittery";
-import { defaultSettings, Settings } from "../../common/settings";
+import { defaultSettings, type Settings } from "../../common/settings";
 import { retrieve, retrieveSettings } from "../../common/storage";
 import { hasMatchingKeys } from "../../lib/utils";
 import { assertDefined } from "../../typings/TypingUtils";

--- a/src/content/setup/initContentScript.ts
+++ b/src/content/setup/initContentScript.ts
@@ -6,12 +6,24 @@ import { initTitleDecoration } from "../utils/decorateTitle";
 import { loadDevtoolsUtils } from "../utils/devtoolsUtils";
 import { loadContentScriptContext } from "./contentScriptContext";
 
-export async function initContentScript() {
-	loadDevtoolsUtils();
-	await loadContentScriptContext();
-	await initSettingsManager();
-	await updateCustomSelectors();
-	await initTitleDecoration();
-	await observe();
-	if (getSetting("keyboardClicking")) initKeyboardClicking();
+let initContentScriptPromise: Promise<void> | undefined;
+
+/**
+ * Initializes the content script. If the content script is currently being
+ * initialized it waits till it's ready. It makes sure that it only runs once
+ * and returns a promise that will resolve once the content script is
+ * initialized.
+ */
+export async function initContentScriptOrWait() {
+	initContentScriptPromise ||= (async () => {
+		loadDevtoolsUtils();
+		await loadContentScriptContext();
+		await initSettingsManager();
+		await updateCustomSelectors();
+		await initTitleDecoration();
+		await observe();
+		if (getSetting("keyboardClicking")) initKeyboardClicking();
+	})();
+
+	return initContentScriptPromise;
 }

--- a/src/content/utils/BoundedIntersectionObserver.ts
+++ b/src/content/utils/BoundedIntersectionObserver.ts
@@ -20,15 +20,14 @@ function isIntersectingViewportMargin(target: Element, margin: number) {
 	);
 }
 
-interface ObservationTargetStatus {
+type ObservationTargetStatus = {
 	// Is intersecting the scroll container or the viewport if root is null, including margins
 	isIntersectingRoot?: boolean;
 	// This can only be true if isIntersectingRoot is true
 	isIntersecting?: boolean;
-}
+};
 
 export class BoundedIntersectionObserver implements IntersectionObserver {
-	readonly callback: IntersectionObserverCallback;
 	readonly root: Element | Document | null;
 	readonly rootMargin: string;
 	readonly rootMarginNumber: number;
@@ -38,10 +37,9 @@ export class BoundedIntersectionObserver implements IntersectionObserver {
 	trueObserver: IntersectionObserver;
 
 	constructor(
-		callback: IntersectionObserverCallback,
+		readonly callback: IntersectionObserverCallback,
 		options: IntersectionObserverInit
 	) {
-		this.callback = callback;
 		this.root = options.root ?? null;
 
 		// For the moment we assume that we will receive just one value for all the margins

--- a/src/content/utils/activateEditable.ts
+++ b/src/content/utils/activateEditable.ts
@@ -1,5 +1,5 @@
 import { sleep } from "../../lib/utils";
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { notify } from "../notify/notify";
 import { getWrapperForElement } from "../wrappers/wrappers";
 import { isEditable, getActiveElement } from "./domUtils";

--- a/src/content/utils/createsStackingContext.ts
+++ b/src/content/utils/createsStackingContext.ts
@@ -1,4 +1,4 @@
-const props =
+const properties =
 	/\b(?:position|zIndex|opacity|mixBlendMode|transform|filter|backdrop-filter|perspective|clip-path|mask|mask-image|mask-border|isolation)\b/;
 
 function isFlexOrGridChild(element: Element) {
@@ -44,7 +44,7 @@ export function createsStackingContext(element: Element) {
 	if ("mask-border" in style && style.filter !== "none") return true;
 
 	if ("isolation" in style && style.isolation === "isolate") return true;
-	if (props.test(style.willChange)) return true;
+	if (properties.test(style.willChange)) return true;
 
 	return false;
 }

--- a/src/content/utils/devtoolsUtils.ts
+++ b/src/content/utils/devtoolsUtils.ts
@@ -1,3 +1,4 @@
+import process from "process";
 import { getHintsCache } from "../hints/hintsCache";
 import { getHintsStackForTab } from "../hints/hintsRequests";
 import {
@@ -8,7 +9,7 @@ import {
 
 // This is not exact but I can't find a definition of exportFunction
 declare function exportFunction(
-	func: Function,
+	function_: Function,
 	target: EventTarget,
 	options: { defineAs: string }
 ): void;
@@ -17,6 +18,7 @@ declare function exportFunction(
 export function loadDevtoolsUtils() {
 	if (
 		process.env["NODE_ENV"] !== "production" &&
+		// eslint-disable-next-line unicorn/no-typeof-undefined
 		typeof exportFunction !== "undefined"
 	) {
 		exportFunction(

--- a/src/content/utils/dispatchEvents.ts
+++ b/src/content/utils/dispatchEvents.ts
@@ -6,6 +6,7 @@ import { getFocusable, isEditable } from "./domUtils";
 // implemented in the other browsers.
 // https://github.com/whatwg/html/pull/8087
 declare global {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-definitions, no-unused-vars
 	interface FocusOptions {
 		focusVisible?: boolean;
 	}

--- a/src/content/utils/domUtils.ts
+++ b/src/content/utils/domUtils.ts
@@ -52,6 +52,6 @@ const focusableSelector =
 export function getFocusable(element: Element) {
 	return element.matches(focusableSelector)
 		? element
-		: element.querySelector(focusableSelector) ??
-				element.closest(focusableSelector);
+		: (element.querySelector(focusableSelector) ??
+				element.closest(focusableSelector));
 }

--- a/src/content/utils/getEffectiveBackgroundColor.ts
+++ b/src/content/utils/getEffectiveBackgroundColor.ts
@@ -1,11 +1,11 @@
 function rgbaToRgb(rgba: string, backgroundRgb: string) {
 	const [r, g, b, a] = rgba
-		.replace(/[^\d.\s,]/g, "")
+		.replaceAll(/[^\d.\s,]/g, "")
 		.split(",")
 		.map((v) => Number.parseFloat(v));
 
 	const [backgroundR, backgroundG, backgroundB] = backgroundRgb
-		.replace(/[^\d.\s,]/g, "")
+		.replaceAll(/[^\d.\s,]/g, "")
 		.split(",")
 		.map((v) => Number.parseFloat(v));
 

--- a/src/content/utils/getUserScrollableContainer.ts
+++ b/src/content/utils/getUserScrollableContainer.ts
@@ -1,4 +1,4 @@
-const containersCache: Map<Element, HTMLElement> = new Map();
+const containersCache = new Map<Element, HTMLElement>();
 
 /**
  * Given an Element return the Element that contains it and might scroll it. It

--- a/src/content/utils/isHintable.ts
+++ b/src/content/utils/isHintable.ts
@@ -3,7 +3,6 @@ import {
 	getShowExcludedToggle,
 } from "../actions/customHints";
 import { matchesStagedSelector } from "../hints/customSelectorsStaging";
-
 import {
 	matchesCustomExclude,
 	matchesCustomInclude,

--- a/src/content/wrappers/ElementWrapperClass.ts
+++ b/src/content/wrappers/ElementWrapperClass.ts
@@ -1,5 +1,6 @@
 import { debounce } from "lodash";
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
+import { type Hint } from "../../typings/Hint";
 import { getExtraHintsToggle } from "../actions/customHints";
 import { openInNewTab } from "../actions/openInNewTab";
 import { HintClass } from "../hints/HintClass";
@@ -150,10 +151,10 @@ const addWrappersIntersectionObserver = new IntersectionObserver(
 
 // INTERSECTION OBSERVER
 
-const scrollIntersectionObservers: Map<
+const scrollIntersectionObservers = new Map<
 	Element | null,
 	BoundedIntersectionObserver
-> = new Map();
+>();
 
 async function intersectionCallback(entries: IntersectionObserverEntry[]) {
 	const entriesIntersecting = entries.filter((entry) => entry.isIntersecting);
@@ -216,10 +217,10 @@ function isNonRangoMutation(mutation: MutationRecord) {
 		mutation.attributeName === "data-hint" ||
 		(mutation.addedNodes.length === 1 &&
 			mutation.addedNodes[0]! instanceof Element &&
-			mutation.addedNodes[0]!.className === "rango-hint") ||
+			mutation.addedNodes[0].className === "rango-hint") ||
 		(mutation.removedNodes.length === 1 &&
 			mutation.removedNodes[0]! instanceof Element &&
-			mutation.removedNodes[0]!.className === "rango-hint");
+			mutation.removedNodes[0].className === "rango-hint");
 
 	return !isRangoMutation;
 }
@@ -322,15 +323,27 @@ document.addEventListener("focusout", debouncedHandleFocusChange);
 // WRAPPER CLASS
 // =============================================================================
 
-// This is necessary to not have to define the Wrapper interface properties again
-interface ElementWrapperClass extends ElementWrapper {}
-
 /**
  * A wrapper for a DOM Element.
  */
 class ElementWrapperClass implements ElementWrapper {
-	constructor(element: Element, active = true) {
-		this.element = element;
+	isIntersecting?: boolean;
+	observingIntersection?: boolean;
+	isIntersectingViewport?: boolean;
+	isActiveEditable: boolean;
+	isHintable: boolean;
+	shouldBeHinted?: boolean;
+
+	// These properties are only needed for hintables
+	intersectionObserver?: BoundedIntersectionObserver;
+	userScrollableContainer?: Element;
+	effectiveBackgroundColor?: string;
+	hint?: Hint;
+
+	constructor(
+		public element: Element,
+		active = true
+	) {
 		this.isActiveEditable =
 			this.element === document.activeElement && isEditable(this.element);
 

--- a/src/content/wrappers/lastWrapper.ts
+++ b/src/content/wrappers/lastWrapper.ts
@@ -1,4 +1,4 @@
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 
 let lastWrapper: ElementWrapper | undefined;
 

--- a/src/content/wrappers/refresh.ts
+++ b/src/content/wrappers/refresh.ts
@@ -49,7 +49,7 @@ function combineOptions(existingOptions: Options, newOptions: Options) {
 
 	let key: keyof Options;
 	for (key in newOptions) {
-		if (Object.prototype.hasOwnProperty.call(newOptions, key)) {
+		if (Object.hasOwn(newOptions, key)) {
 			if (key === "filterIn") {
 				if (!existingOptions.filterIn) continue;
 
@@ -78,7 +78,11 @@ function combineOptions(existingOptions: Options, newOptions: Options) {
  * @returns An array of ElementWrappers that need to be updated.
  */
 function getElementWrappersToUpdate(options: Options) {
-	const { hintsCharacters, isHintable, shouldBeHinted } = options;
+	const {
+		hintsCharacters = false,
+		isHintable = false,
+		shouldBeHinted = false,
+	} = options;
 
 	const wrappersToUpdate =
 		isHintable || shouldBeHinted ? getAllWrappers() : getHintedWrappers();

--- a/src/content/wrappers/wrappers.ts
+++ b/src/content/wrappers/wrappers.ts
@@ -1,9 +1,9 @@
-import { ElementWrapper } from "../../typings/ElementWrapper";
+import { type ElementWrapper } from "../../typings/ElementWrapper";
 import { getToggles } from "../settings/toggles";
 import { deepGetElements } from "../utils/deepGetElements";
 
-const wrappersAll: Map<Element, ElementWrapper> = new Map();
-const wrappersHinted: Map<string, ElementWrapper> = new Map();
+const wrappersAll = new Map<Element, ElementWrapper>();
+const wrappersHinted = new Map<string, ElementWrapper>();
 
 export function getAllWrappers() {
 	return [...wrappersAll.values()];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,8 @@
-export function hasMatchingKeys(object1: object, object2: object): boolean {
-	const keys1 = Array.isArray(object1)
-		? Object.values(object1)
-		: Object.keys(object1);
+export function hasMatchingKeys(
+	object1: Record<string, unknown>,
+	object2: Record<string, unknown>
+): boolean {
+	const keys1 = Object.keys(object1);
 	const keys2 = Object.keys(object2);
 
 	return keys1.some((key) => keys2.includes(key));

--- a/src/settings/Alert.tsx
+++ b/src/settings/Alert.tsx
@@ -21,8 +21,8 @@ const icons = {
 };
 
 type AlertProps = {
-	type: keyof typeof icons;
-	children?: React.ReactNode;
+	readonly type: keyof typeof icons;
+	readonly children?: React.ReactNode;
 };
 
 export function Alert({ type, children }: AlertProps) {

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -7,7 +7,7 @@ import { Alert } from "./Alert";
 const iconSvgUrl = new URL("../assets/icon.svg", import.meta.url);
 
 type AppProps = {
-	hasSeenSettingsPage: boolean;
+	readonly hasSeenSettingsPage: boolean;
 };
 
 export function App({ hasSeenSettingsPage }: AppProps) {

--- a/src/settings/CustomHintsSetting.tsx
+++ b/src/settings/CustomHintsSetting.tsx
@@ -1,19 +1,19 @@
 import { faBan, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { CustomSelector } from "../typings/StorageSchema";
-import "./CustomHintsSetting.css";
 import { isValidSelector } from "../common/selectorUtils";
 import { isValidRegExp } from "../common/textUtils";
+import { type CustomSelector } from "../typings/StorageSchema";
+import "./CustomHintsSetting.css";
 
-type CustomHintsSettingProp = {
-	value: CustomSelector[];
+type CustomHintsSettingProps = {
+	readonly value: CustomSelector[];
 	onChange(value: CustomSelector[]): void;
 };
 
 export function CustomHintsSetting({
 	value,
 	onChange,
-}: CustomHintsSettingProp) {
+}: CustomHintsSettingProps) {
 	function handleChange(
 		event: React.ChangeEvent<HTMLInputElement>,
 		key: "pattern" | "selector",

--- a/src/settings/ExcludeKeysSetting.tsx
+++ b/src/settings/ExcludeKeysSetting.tsx
@@ -1,9 +1,9 @@
 import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
-import "./ExcludeKeysSetting.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import "./ExcludeKeysSetting.css";
 
 type ExcludeKeysSettingProps = {
-	value: Array<[string, string]>;
+	readonly value: Array<[string, string]>;
 	onChange(value: Array<[string, string]>): void;
 };
 

--- a/src/settings/NumberInput.tsx
+++ b/src/settings/NumberInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useId } from "react";
+import { type ChangeEvent, useId } from "react";
 import "./Input.css";
 import { Alert } from "./Alert";
 
@@ -8,14 +8,14 @@ function parseNumber(numberString: string) {
 }
 
 type InputProps = {
-	label: string;
-	defaultValue: number;
-	step?: number;
-	min?: number;
-	max?: number;
-	isDisabled?: boolean;
-	isValid?: boolean;
-	children?: React.ReactNode;
+	readonly label: string;
+	readonly defaultValue: number;
+	readonly step?: number;
+	readonly min?: number;
+	readonly max?: number;
+	readonly isDisabled?: boolean;
+	readonly isValid?: boolean;
+	readonly children?: React.ReactNode;
 	onChange(value: number): void;
 	onBlur(): void;
 };

--- a/src/settings/RadioGroup.tsx
+++ b/src/settings/RadioGroup.tsx
@@ -1,14 +1,14 @@
-import { createContext, ReactNode, useContext, useMemo } from "react";
+import { createContext, type ReactNode, useContext, useMemo } from "react";
 import "./RadioGroup.css";
 
-type TRadioContext = {
+type TypeRadioContext = {
 	name: string;
 	selectedValue: string;
 	isDisabled?: boolean;
 	onChange(value: string): void;
 };
 
-const RadioContext = createContext<TRadioContext>({
+const RadioContext = createContext<TypeRadioContext>({
 	name: "",
 	selectedValue: "",
 	isDisabled: false,
@@ -17,8 +17,8 @@ const RadioContext = createContext<TRadioContext>({
 });
 
 type RadioProps = {
-	value: string;
-	children: ReactNode;
+	readonly value: string;
+	readonly children: ReactNode;
 };
 
 export function Radio({ value, children }: RadioProps) {
@@ -44,11 +44,11 @@ export function Radio({ value, children }: RadioProps) {
 }
 
 type RadioGroupProps<T extends string> = {
-	label: string;
-	name: string;
-	defaultValue: T;
-	isDisabled?: boolean;
-	children: ReactNode;
+	readonly label: string;
+	readonly name: string;
+	readonly defaultValue: T;
+	readonly isDisabled?: boolean;
+	readonly children: ReactNode;
 	onChange(value: T): void;
 };
 

--- a/src/settings/Select.tsx
+++ b/src/settings/Select.tsx
@@ -1,9 +1,9 @@
-import { ReactNode } from "react";
+import { type ReactNode } from "react";
 import "./Select.css";
 
 type OptionProps = {
-	value: string;
-	children: ReactNode;
+	readonly value: string;
+	readonly children: ReactNode;
 };
 
 export function Option({ value, children }: OptionProps) {
@@ -11,10 +11,10 @@ export function Option({ value, children }: OptionProps) {
 }
 
 type SelectProps<T extends string> = {
-	label: string;
-	defaultValue: T;
-	children: ReactNode;
-	isDisabled: boolean;
+	readonly label: string;
+	readonly defaultValue: T;
+	readonly children: ReactNode;
+	readonly isDisabled: boolean;
 	onChange(value: T): void;
 };
 

--- a/src/settings/SettingsComponent.tsx
+++ b/src/settings/SettingsComponent.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import Color from "color";
 import { defaultSettingsMutable, isValidSetting } from "../common/settings";
 import { retrieveSettings, store } from "../common/storage";
-import { StorageSchema } from "../typings/StorageSchema";
+import { type StorageSchema } from "../typings/StorageSchema";
 import { hasMatchingKeys } from "../lib/utils";
 import { SettingsGroup } from "./SettingsGroup";
 import { Toggle } from "./Toggle";

--- a/src/settings/SettingsGroup.tsx
+++ b/src/settings/SettingsGroup.tsx
@@ -1,8 +1,8 @@
 import "./SettingsGroup.css";
 
 type SettingsGroupProps = {
-	label: string;
-	children: React.ReactNode;
+	readonly label: string;
+	readonly children: React.ReactNode;
 };
 
 export function SettingsGroup({ label, children }: SettingsGroupProps) {

--- a/src/settings/TextInput.tsx
+++ b/src/settings/TextInput.tsx
@@ -2,10 +2,10 @@ import { useId } from "react";
 import "./Input.css";
 
 type InputProps = {
-	label: string;
-	defaultValue: string | number;
-	isValid?: boolean;
-	children?: React.ReactNode;
+	readonly label: string;
+	readonly defaultValue: string | number;
+	readonly isValid?: boolean;
+	readonly children?: React.ReactNode;
 	onChange(value: string): void;
 	onBlur?(): void;
 };

--- a/src/settings/Toggle.tsx
+++ b/src/settings/Toggle.tsx
@@ -1,10 +1,10 @@
 import "./Toggle.css";
 
 type ToggleProps = {
-	label: string;
-	isPressed: boolean;
-	isDisabled?: boolean;
-	children?: React.ReactNode;
+	readonly label: string;
+	readonly isPressed: boolean;
+	readonly isDisabled?: boolean;
+	readonly children?: React.ReactNode;
 	onClick(): void;
 };
 

--- a/src/typings/ElementWrapper.ts
+++ b/src/typings/ElementWrapper.ts
@@ -1,5 +1,5 @@
-import { BoundedIntersectionObserver } from "../content/utils/BoundedIntersectionObserver";
-import { Hint } from "./Hint";
+import { type BoundedIntersectionObserver } from "../content/utils/BoundedIntersectionObserver";
+import { type Hint } from "./Hint";
 
 /**
  * A wrapper for a DOM Element.
@@ -8,7 +8,7 @@ import { Hint } from "./Hint";
  * is to avoid cycle dependencies since ElementWrapperClass must import other modules
  * that also import ElementWrapper.
  */
-export interface ElementWrapper {
+export type ElementWrapper = {
 	element: Element;
 
 	isIntersecting?: boolean;
@@ -44,4 +44,4 @@ export interface ElementWrapper {
 	 * This method should be called when the element is removed from the DOM.
 	 */
 	suspend(): void;
-}
+};

--- a/src/typings/Hint.ts
+++ b/src/typings/Hint.ts
@@ -1,6 +1,6 @@
-import Color from "color";
+import type Color from "color";
 
-export interface Hint {
+export type Hint = {
 	/**
 	 * The Element the hint is referencing.
 	 */
@@ -35,7 +35,6 @@ export interface Hint {
 	updateColors(): void;
 	claim(): string | undefined;
 	position(): void;
-	display(): void;
 	flash(ms?: number): void;
 	clearFlash(): void;
 
@@ -53,4 +52,4 @@ export interface Hint {
 	applyDefaultStyle(): void;
 	keyHighlight(): void;
 	clearKeyHighlight(): void;
-}
+};

--- a/src/typings/RangoAction.ts
+++ b/src/typings/RangoAction.ts
@@ -1,4 +1,4 @@
-interface RangoActionWithoutTargetWithoutArg {
+type RangoActionWithoutTargetWithoutArgument = {
 	type:
 		| "historyGoBack"
 		| "historyGoForward"
@@ -53,14 +53,14 @@ interface RangoActionWithoutTargetWithoutArg {
 		| "checkActiveElementIsEditable"
 		| "refreshTabMarkers"
 		| "showReferences";
-}
+};
 
-export interface RangoActionUpdateToggles {
+export type RangoActionUpdateToggles = {
 	type: "enableHints" | "disableHints" | "resetToggleLevel";
 	arg: "everywhere" | "global" | "tab" | "host" | "page" | "now";
-}
+};
 
-export interface RangoActionCopyLocationProperty {
+export type RangoActionCopyLocationProperty = {
 	type: "copyLocationProperty";
 	arg:
 		| "href"
@@ -70,19 +70,19 @@ export interface RangoActionCopyLocationProperty {
 		| "pathname"
 		| "port"
 		| "protocol";
-}
+};
 
-interface RangoActionSetHintStyle {
+type RangoActionSetHintStyle = {
 	type: "setHintStyle";
 	arg: "boxed" | "subtle";
-}
+};
 
-interface RangoActionSetHintWeight {
+type RangoActionSetHintWeight = {
 	type: "setHintWeight";
 	arg: "auto" | "normal" | "bold";
-}
+};
 
-interface RangoActionWithoutTargetWithNumberArg {
+type RangoActionWithoutTargetWithNumberArgument = {
 	type:
 		| "closeTabsLeftEndInWindow"
 		| "closeTabsRightEndInWindow"
@@ -90,14 +90,14 @@ interface RangoActionWithoutTargetWithNumberArg {
 		| "closeNextTabsInWindow"
 		| "cycleTabsByText";
 	arg: number;
-}
+};
 
-export interface RangoActionRemoveReference {
+export type RangoActionRemoveReference = {
 	type: "removeReference";
 	arg: string;
-}
+};
 
-interface RangoActionWithoutTargetWithOptionalNumberArg {
+type RangoActionWithoutTargetWithOptionalNumberArgument = {
 	type:
 		| "scrollUpPage"
 		| "scrollDownPage"
@@ -108,9 +108,9 @@ interface RangoActionWithoutTargetWithOptionalNumberArg {
 		| "scrollUpRightAside"
 		| "scrollDownRightAside";
 	arg?: number;
-}
+};
 
-export interface RangoActionWithTargets {
+export type RangoActionWithTargets = {
 	type:
 		| "activateTab"
 		| "muteTab"
@@ -137,9 +137,9 @@ export interface RangoActionWithTargets {
 		| "focusAndDeleteContents"
 		| "hideHint";
 	target: string[];
-}
+};
 
-interface RangoActionWithTargetsWithOptionalNumberArg {
+type RangoActionWithTargetsWithOptionalNumberArgument = {
 	type:
 		| "scrollUpAtElement"
 		| "scrollDownAtElement"
@@ -147,50 +147,50 @@ interface RangoActionWithTargetsWithOptionalNumberArg {
 		| "scrollRightAtElement";
 	target: string[];
 	arg?: number;
-}
+};
 
-interface RangoActionSaveReference {
+type RangoActionSaveReference = {
 	type: "saveReference";
 	target: string[];
 	arg: string;
-}
+};
 
-interface RangoActionSaveReferenceForActiveElement {
+type RangoActionSaveReferenceForActiveElement = {
 	type: "saveReferenceForActiveElement";
 	arg: string;
-}
+};
 
-export interface RangoActionRunActionOnReference {
+export type RangoActionRunActionOnReference = {
 	type: "runActionOnReference";
 	arg: RangoActionWithTargets["type"];
 	arg2: string;
-}
+};
 
-interface RangoActionInsertToField {
+type RangoActionInsertToField = {
 	type: "insertToField";
 	target: string[];
 	arg: string;
-}
+};
 
-interface RangoActionOpenPageInNewTab {
+type RangoActionOpenPageInNewTab = {
 	type: "openPageInNewTab";
 	arg: string;
-}
+};
 
-interface RangoActionScrollPosition {
+type RangoActionScrollPosition = {
 	type: "storeScrollPosition" | "scrollToPosition";
 	arg: string;
-}
+};
 
-interface RangoActionfocusOrCreateTabByUrl {
+type RangoActionfocusOrCreateTabByUrl = {
 	type: "focusOrCreateTabByUrl";
 	arg: string;
-}
+};
 
-interface RangoActionFocusTabByText {
+type RangoActionFocusTabByText = {
 	type: "focusTabByText";
 	arg: string;
-}
+};
 
 type RangoActionRunActionOnTextMatchedElement =
 	| {
@@ -211,15 +211,15 @@ type RangoActionRunActionOnTextMatchedElement =
 
 export type RangoActionWithTarget =
 	| RangoActionWithTargets
-	| RangoActionWithTargetsWithOptionalNumberArg
+	| RangoActionWithTargetsWithOptionalNumberArgument
 	| RangoActionInsertToField
 	| RangoActionSaveReference;
 
 export type RangoActionWithoutTarget =
-	| RangoActionWithoutTargetWithoutArg
+	| RangoActionWithoutTargetWithoutArgument
 	| RangoActionUpdateToggles
-	| RangoActionWithoutTargetWithNumberArg
-	| RangoActionWithoutTargetWithOptionalNumberArg
+	| RangoActionWithoutTargetWithNumberArgument
+	| RangoActionWithoutTargetWithOptionalNumberArgument
 	| RangoActionSetHintStyle
 	| RangoActionSetHintWeight
 	| RangoActionCopyLocationProperty
@@ -233,12 +233,3 @@ export type RangoActionWithoutTarget =
 	| RangoActionRunActionOnTextMatchedElement;
 
 export type RangoAction = RangoActionWithTarget | RangoActionWithoutTarget;
-
-// Utilities
-type RangoActionWithArg = RangoAction & { arg?: number | string };
-
-export function hasArg(
-	action: RangoActionWithArg
-): action is RangoActionWithArg {
-	return action.arg !== undefined;
-}

--- a/src/typings/RequestFromBackground.ts
+++ b/src/typings/RequestFromBackground.ts
@@ -1,33 +1,33 @@
-import { ToastOptions } from "react-toastify";
-import { RangoAction } from "./RangoAction";
-import { MarkHintsAsKeyboardReachable } from "./RequestFromContent";
+import { type ToastOptions } from "react-toastify";
+import { type RangoAction } from "./RangoAction";
+import { type MarkHintsAsKeyboardReachable } from "./RequestFromContent";
 
-interface UpdateHintsInTab {
+type UpdateHintsInTab = {
 	type: "updateHintsInTab";
 	hints: string[];
-}
+};
 
-interface ReclaimHints {
+type ReclaimHints = {
 	type: "reclaimHints";
 	amount: number;
-}
+};
 
-interface DisplayToastNotification {
+type DisplayToastNotification = {
 	type: "displayToastNotification";
 	text: string;
 	options?: ToastOptions;
-}
+};
 
-interface AllowToastNotification {
+type AllowToastNotification = {
 	type: "allowToastNotification";
-}
+};
 
-interface UpdateNavigationToggle {
+type UpdateNavigationToggle = {
 	type: "updateNavigationToggle";
 	enable: boolean | undefined;
-}
+};
 
-interface SimpleContentRequest {
+type SimpleContentRequest = {
 	type:
 		| "restoreKeyboardReachableHints"
 		| "checkIfDocumentHasFocus"
@@ -36,7 +36,7 @@ interface SimpleContentRequest {
 		| "tryToFocusPage"
 		| "getTitleBeforeDecoration"
 		| "refreshTitleDecorations";
-}
+};
 
 export type RequestFromBackground = { frameId?: number } & (
 	| RangoAction

--- a/src/typings/RequestFromContent.ts
+++ b/src/typings/RequestFromContent.ts
@@ -1,62 +1,62 @@
-import { CustomSelector } from "./StorageSchema";
+import { type CustomSelector } from "./StorageSchema";
 
-interface OpenInNewTab {
+type OpenInNewTab = {
 	type: "openInNewTab";
 	url: string;
-}
-interface OpenInBackgroundTab {
+};
+type OpenInBackgroundTab = {
 	type: "openInBackgroundTab";
 	links: string[];
-}
+};
 
-interface ClaimHints {
+type ClaimHints = {
 	type: "claimHints";
 	amount: number;
-}
+};
 
-interface ReleaseHints {
+type ReleaseHints = {
 	type: "releaseHints";
 	hints: string[];
-}
+};
 
-interface ClickHintInFrame {
+type ClickHintInFrame = {
 	type: "clickHintInFrame";
 	hint: string;
-}
+};
 
-export interface MarkHintsAsKeyboardReachable {
+export type MarkHintsAsKeyboardReachable = {
 	type: "markHintsAsKeyboardReachable";
 	letter: string;
-}
+};
 
-interface ReclaimHintsFromOtherFrames {
+type ReclaimHintsFromOtherFrames = {
 	type: "reclaimHintsFromOtherFrames";
 	amount: number;
-}
+};
 
-interface StoreHintsInFrame {
+type StoreHintsInFrame = {
 	type: "storeHintsInFrame";
 	hints: string[];
-}
+};
 
-interface StoreCustomSelectors {
+type StoreCustomSelectors = {
 	type: "storeCustomSelectors";
 	url: string;
 	selectors: CustomSelector[];
-}
+};
 
-interface ResetCustomSelectors {
+type ResetCustomSelectors = {
 	type: "resetCustomSelectors";
 	url: string;
-}
+};
 
-interface RemoveReference {
+type RemoveReference = {
 	type: "removeReference";
 	hostPattern: string;
 	name: string;
-}
+};
 
-interface SimpleRequestFromContent {
+type SimpleRequestFromContent = {
 	type:
 		| "initStack"
 		| "getContentScriptContext"
@@ -64,7 +64,7 @@ interface SimpleRequestFromContent {
 		| "getHintsStackForTab"
 		| "isCurrentTab"
 		| "getTabMarker";
-}
+};
 
 export type RequestFromContent =
 	| SimpleRequestFromContent

--- a/src/typings/RequestFromTalon.ts
+++ b/src/typings/RequestFromTalon.ts
@@ -1,53 +1,53 @@
-import { RangoAction } from "./RangoAction";
+import { type RangoAction } from "./RangoAction";
 
-export interface RequestFromTalon {
+export type RequestFromTalon = {
 	version?: number;
 	type: "request";
 	action: RangoAction;
-}
+};
 
-interface TalonActionCopyToClipboard {
+type TalonActionCopyToClipboard = {
 	name: "copyToClipboard";
 	textToCopy: string;
-}
+};
 
-interface TalonActionTypeTargetCharacters {
+type TalonActionTypeTargetCharacters = {
 	name: "typeTargetCharacters";
 	previousName?: "noHintFound";
-}
+};
 
-interface TalonActionKey {
+type TalonActionKey = {
 	name: "key";
 	key: string;
-}
+};
 
-interface TalonActionEditDelete {
+type TalonActionEditDelete = {
 	name: "editDelete";
 	previousName?: "editDeleteAfterDelay";
-}
+};
 
-interface TalonActionSleep {
+type TalonActionSleep = {
 	name: "sleep";
 	ms?: number;
-}
+};
 
-interface TalonActionFocusPage {
+type TalonActionFocusPage = {
 	name: "focusPage";
-}
+};
 
-interface TalonActionFocusPageAndResend {
+type TalonActionFocusPageAndResend = {
 	name: "focusPageAndResend";
-}
+};
 
-interface TalonActionResponseValue {
+type TalonActionResponseValue = {
 	name: "responseValue";
 	value: any;
-}
+};
 
-interface TalonActionOpenInNewTab {
+type TalonActionOpenInNewTab = {
 	name: "openInNewTab";
 	url: string;
-}
+};
 
 export type TalonAction = { main?: true } & (
 	| TalonActionCopyToClipboard
@@ -61,13 +61,13 @@ export type TalonAction = { main?: true } & (
 	| TalonActionOpenInNewTab
 );
 
-export interface ResponseToTalon {
+export type ResponseToTalon = {
 	type: "response";
 	action: TalonActionLegacy;
 	actions: TalonAction[];
-}
+};
 
-export interface TalonActionLegacy {
+export type TalonActionLegacy = {
 	type:
 		| "noAction"
 		| "copyToClipboard"
@@ -77,4 +77,4 @@ export interface TalonActionLegacy {
 		| "editDeleteAfterDelay";
 	textToCopy?: string;
 	key?: string;
-}
+};

--- a/src/typings/SelectorAlternative.ts
+++ b/src/typings/SelectorAlternative.ts
@@ -1,5 +1,5 @@
-export interface SelectorAlternative {
+export type SelectorAlternative = {
 	selector: string;
 	specificity: number;
 	elementsMatching: number;
-}
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"outDir": "dist",
 		"esModuleInterop": true,
-		"lib": ["es2021", "ES2021.String", "DOM", "DOM.Iterable"],
+		"lib": ["es2022", "DOM", "DOM.Iterable"],
 		"strictPropertyInitialization": false,
 		"jsx": "react-jsx",
 		"noErrorTruncation": true


### PR DESCRIPTION
This PR updates some dependencies and fixes the consequent linting errors.

- Update caniuse-lite to 1.0.30001662
- Update @babel/traverse to 7.24.7
- Update jest-puppeteer to 10.1.1
- Update dependency xo to 0.59.3.
- Move xo configuration to its own file.
- Update eslint plugins.
- New linting rule changes:
  - Replace imports for type imports when importing types.
  - Replace some abbreviations for their full form (e.g. resolve instead of r).
  - Enclose switch cases within brackets.
  - Always include braces in switch cases.
  - Import process instead of using the global variable.
  - Prefer Math.hypot.
  - Prefer type to interface.
  - Prefer parameter properties in classes.
  - Make all Props read-only
  - Prefer replaceAll over replace.
- Change lib in tsconfig to "ES2022".
  - Simplify code using Array.at().
- Include properties in classes even when using "implements".
- Fix hasMatchingKeys parameter types.
- Make sure content script is initialized before running any command.