### PR TITLE
Use global process variable so that Parcel can replace it at build time with its corresponding value

### DIFF
--- a/.xo-config.json
+++ b/.xo-config.json
@@ -13,6 +13,7 @@
 	},
 	"rules": {
 		"@typescript-eslint/switch-exhaustiveness-check": "off",
+		"n/prefer-global/process": "off",
 		"no-unused-vars": [
 			"error",
 			{

--- a/src/background/messaging/handleRequestFromTalon.ts
+++ b/src/background/messaging/handleRequestFromTalon.ts
@@ -1,4 +1,3 @@
-import process from "process";
 import { retrieve } from "../../common/storage";
 import { promiseWrap } from "../../lib/promiseWrap";
 import { type RequestFromTalon } from "../../typings/RequestFromTalon";

--- a/src/background/setup/initBackgroundScript.ts
+++ b/src/background/setup/initBackgroundScript.ts
@@ -1,4 +1,3 @@
-import process from "process";
 import browser from "webextension-polyfill";
 import { retrieve, store } from "../../common/storage";
 import { urls } from "../../common/urls";

--- a/src/content/actions/scroll.ts
+++ b/src/content/actions/scroll.ts
@@ -1,4 +1,3 @@
-import process from "process";
 import { isHtmlElement } from "../../typings/TypingUtils";
 import { getUserScrollableContainer } from "../utils/getUserScrollableContainer";
 import { type ElementWrapper } from "../../typings/ElementWrapper";

--- a/src/content/hints/HintClass.ts
+++ b/src/content/hints/HintClass.ts
@@ -1,4 +1,3 @@
-import process from "process";
 import Color from "color";
 import { debounce } from "lodash";
 import { rgbaToRgb } from "../../lib/rgbaToRgb";

--- a/src/content/utils/devtoolsUtils.ts
+++ b/src/content/utils/devtoolsUtils.ts
@@ -1,4 +1,3 @@
-import process from "process";
 import { getHintsCache } from "../hints/hintsCache";
 import { getHintsStackForTab } from "../hints/hintsRequests";
 import {


### PR DESCRIPTION
When I updated XO this new rule was present: [eslint-plugin-n/docs/rules/prefer-global/process.md](https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/process.md). This made that instead of using the global process I imported it, thinking it would be the same.

```typescript
import process from "process";
```

The thing is process is a Node variable. It isn't available in the front end. So the following line, for example:

```typescript
if (process.env["NODE_ENV"] !== "production") return "instant";
```

Is equivalent to this:

```typescript
if (undefined !== "production") return "instant";
```

The comparison is always true, that's the reason we always got the "instant" behavior.

But if instead of importing process we use the global variable, Parcel replaces the value of `process.env["NODE_ENV"]` at build time and removes the branch or the condition if it can.