### PR TITLE
Make e2e tests run headless

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,18 +10,14 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npx lockfile-lint --path package-lock.json --validate-https
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm install
-      - uses: david-tejada/puppeteer-headful@master
-        with:
-          args: npm test
+      - run: npm test

--- a/e2e/noContentScript.test.ts
+++ b/e2e/noContentScript.test.ts
@@ -1,9 +1,9 @@
-import clipboard from "clipboardy";
 import { type ResponseToTalon } from "../src/typings/RequestFromTalon";
 import {
 	rangoCommandWithTarget,
 	rangoCommandWithoutTarget,
 } from "./utils/rangoCommands";
+import { storageClipboard } from "./utils/serviceWorker";
 import { sleep } from "./utils/testHelpers";
 
 beforeEach(async () => {
@@ -14,7 +14,7 @@ describe("Direct clicking", () => {
 	test("If no content script is loaded in the current page it sends the command to talon to type the characters", async () => {
 		await rangoCommandWithTarget("directClickElement", ["a"]);
 		await sleep(300);
-		const clip = clipboard.readSync();
+		const clip = await storageClipboard.readText();
 		const response = JSON.parse(clip) as ResponseToTalon;
 		const found = response.actions.find(
 			(action) => action.name === "typeTargetCharacters"
@@ -27,7 +27,7 @@ describe("Direct clicking", () => {
 describe("Background commands", () => {
 	test("Commands that don't need the content script are still able to run", async () => {
 		await rangoCommandWithoutTarget("copyLocationProperty", "href");
-		const clip = clipboard.readSync();
+		const clip = await storageClipboard.readText();
 		const response = JSON.parse(clip) as ResponseToTalon;
 		const action = response.actions[0]!;
 

--- a/e2e/scroll.test.ts
+++ b/e2e/scroll.test.ts
@@ -7,6 +7,8 @@ import {
 import { sleep } from "./utils/testHelpers";
 import { getHintForElement } from "./utils/getHintForElement";
 
+jest.retryTimes(3);
+
 function getCenter(element: Element) {
 	const { top, height } = element.getBoundingClientRect();
 	return top + height / 2;

--- a/e2e/utils/rangoCommands.ts
+++ b/e2e/utils/rangoCommands.ts
@@ -1,17 +1,18 @@
 /* eslint-disable no-await-in-loop */
-import { keyTap } from "@hurdlegroup/robotjs";
-import clipboard from "clipboardy";
+import { storageClipboard, runTestRequest } from "./serviceWorker";
 import { sleep } from "./testHelpers";
 
-async function waitForCompletion() {
+async function waitResponseReady() {
 	let message: any;
 
 	while (!message || message.type !== "response") {
-		const clip = clipboard.readSync();
+		const clip = await storageClipboard.readText();
 
 		try {
 			message = JSON.parse(clip) as unknown;
-		} catch {}
+		} catch {
+			// Ignore parsing errors
+		}
 
 		await sleep(10);
 	}
@@ -32,11 +33,10 @@ export async function rangoCommandWithTarget(
 		},
 	};
 
-	const commandString = JSON.stringify(command);
+	const request = JSON.stringify(command);
 
-	clipboard.writeSync(commandString);
-	keyTap("3", ["control", "shift"]);
-	await waitForCompletion();
+	await runTestRequest(request);
+	await waitResponseReady();
 }
 
 export async function rangoCommandWithoutTarget(
@@ -52,9 +52,8 @@ export async function rangoCommandWithoutTarget(
 		},
 	};
 
-	const commandString = JSON.stringify(command);
+	const request = JSON.stringify(command);
 
-	clipboard.writeSync(commandString);
-	keyTap("3", ["control", "shift"]);
-	await waitForCompletion();
+	await runTestRequest(request);
+	await waitResponseReady();
 }

--- a/e2e/utils/serviceWorker.ts
+++ b/e2e/utils/serviceWorker.ts
@@ -1,0 +1,41 @@
+import { TargetType } from "puppeteer";
+
+async function getServiceWorker() {
+	const workerTarget = await browser.waitForTarget(
+		(target) => target.type() === TargetType.SERVICE_WORKER
+	);
+
+	return (await workerTarget.worker())!;
+}
+
+/**
+ * This is used to make headless testing possible. Because in Chrome for Testing
+ * `document.execCommand` doesn't work we need a way to test without using the
+ * real clipboard. It reads and writes from and to local storage.
+ */
+export const storageClipboard = {
+	async readText() {
+		const worker = await getServiceWorker();
+		const { clipboard } = (await worker.evaluate(async () =>
+			chrome.storage.local.get("clipboard")
+		)) as { clipboard: string };
+
+		return clipboard;
+	},
+	async writeText(text: string) {
+		const worker = await getServiceWorker();
+
+		await worker.evaluate(async (text) => {
+			await chrome.storage.local.set({ clipboard: text });
+		}, text);
+	},
+};
+
+export async function runTestRequest(request: string) {
+	const worker = await getServiceWorker();
+
+	await worker.evaluate(async (request) => {
+		await chrome.storage.local.set({ clipboard: request });
+		dispatchEvent(new CustomEvent("handle-test-request"));
+	}, request);
+}

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -5,10 +5,10 @@ module.exports = {
 	launch: {
 		dumpio: false,
 		devtools: false,
-		headless: false,
 		product: "chrome",
 		executablePath: process.env.PUPPETEER_EXEC_PATH,
 		args: [
+			"--remote-debugging-port=9222",
 			"--no-sandbox",
 			`--disable-extensions-except=${EXTENSION_PATH}`,
 			`--load-extension=${EXTENSION_PATH}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
 				"zod": "^3.22.4"
 			},
 			"devDependencies": {
-				"@hurdlegroup/robotjs": "^0.12.2",
 				"@parcel/config-webextension": "^2.5.0",
 				"@sindresorhus/tsconfig": "^2.0.0",
 				"@types/chrome": "^0.0.272",
@@ -39,7 +38,6 @@
 				"@types/lodash": "^4.14.195",
 				"@types/react-dom": "^18.0.11",
 				"@types/webextension-polyfill": "^0.12.1",
-				"clipboardy": "^2.3.0",
 				"eslint-config-xo-react": "^0.27.0",
 				"eslint-plugin-react": "^7.36.1",
 				"eslint-plugin-react-hooks": "^4.6.2",
@@ -970,17 +968,6 @@
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true
-		},
-		"node_modules/@hurdlegroup/robotjs": {
-			"version": "0.12.2",
-			"resolved": "https://registry.npmjs.org/@hurdlegroup/robotjs/-/robotjs-0.12.2.tgz",
-			"integrity": "sha512-hv2qcNfKuMlctHLcGHWltHaxKPB4PMjqnsPNuNaHwrBYq6bwGodKyqCPTJFE918IJZoJuSTmMD1E+axQAe0ItQ==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"node-addon-api": "*",
-				"node-gyp-build": "^4.8.1"
-			}
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
@@ -4717,26 +4704,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/arch": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-			"integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5830,20 +5797,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/clipboardy": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
-			"integrity": "sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==",
-			"dev": true,
-			"dependencies": {
-				"arch": "^2.1.1",
-				"execa": "^1.0.0",
-				"is-wsl": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/cliui": {
@@ -8248,91 +8201,6 @@
 				"node": ">=0.8.x"
 			}
 		},
-		"node_modules/execa": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^6.0.0",
-				"get-stream": "^4.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/execa/node_modules/cross-spawn": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-			"dev": true,
-			"dependencies": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			},
-			"engines": {
-				"node": ">=4.8"
-			}
-		},
-		"node_modules/execa/node_modules/path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/execa/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
-		"node_modules/execa/node_modules/shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-			"dev": true,
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/execa/node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/execa/node_modules/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"which": "bin/which"
-			}
-		},
 		"node_modules/exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -9206,18 +9074,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-			"dev": true,
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/get-symbol-description": {
@@ -10438,15 +10294,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-string": {
@@ -12880,15 +12727,6 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"node_modules/node-addon-api": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
-			"integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ==",
-			"dev": true,
-			"engines": {
-				"node": "^18 || ^20 || >= 21"
-			}
-		},
 		"node_modules/node-forge": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -12896,17 +12734,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 6.13.0"
-			}
-		},
-		"node_modules/node-gyp-build": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
-			"integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
-			"dev": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/node-gyp-build-optional-packages": {
@@ -13166,27 +12993,6 @@
 			},
 			"bin": {
 				"which": "bin/which"
-			}
-		},
-		"node_modules/npm-run-path": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-			"dev": true,
-			"dependencies": {
-				"path-key": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-run-path/node_modules/path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/nth-check": {
@@ -13785,15 +13591,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
 			"integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -16417,15 +16214,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/strip-eof": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/strip-final-newline": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
 		"zod": "^3.22.4"
 	},
 	"devDependencies": {
-		"@hurdlegroup/robotjs": "^0.12.2",
 		"@parcel/config-webextension": "^2.5.0",
 		"@sindresorhus/tsconfig": "^2.0.0",
 		"@types/chrome": "^0.0.272",
@@ -73,7 +72,6 @@
 		"@types/lodash": "^4.14.195",
 		"@types/react-dom": "^18.0.11",
 		"@types/webextension-polyfill": "^0.12.1",
-		"clipboardy": "^2.3.0",
 		"eslint-config-xo-react": "^0.27.0",
 		"eslint-plugin-react": "^7.36.1",
 		"eslint-plugin-react-hooks": "^4.6.2",

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -17,6 +17,8 @@ browser.contextMenus.onClicked.addListener(contextMenusOnClicked);
 	await initBackgroundScript();
 })();
 
+addEventListener("handle-test-request", handleRequestFromTalon);
+
 browser.runtime.onMessage.addListener(async (message, sender) => {
 	return handleRequestFromContent(message as RequestFromContent, sender);
 });


### PR DESCRIPTION
This PR makes tests run headless. I wasn't able to make the tests use the system clipboard because [`document.execCommand` doesn't work in headless mode](https://github.com/GoogleChromeLabs/chrome-for-testing/issues/154) in Chrome for Testing. Instead of that I use a simulated clipboard using the extension's own local storage. This makes that the reading from and writing to the clipboard is not tested. I don't think it matters since that breaking would be immediately noticeable. We were only testing the clipboard read and write implementation for manifest v3 anyway. This also make us not rely on the clipboard in case in the future communication between Talon and the extension is made using talon-rpc.
