### PR TITLE
Simplify error handling in background script

### DIFF
--- a/src/background/actions/openInNewTab.ts
+++ b/src/background/actions/openInNewTab.ts
@@ -28,18 +28,14 @@ export async function openInNewTab(urls: string[], active: boolean) {
 		index = 99_999;
 	}
 
-	try {
-		await Promise.all(
-			urls.map(async (url) =>
-				browser.tabs.create({
-					url,
-					active,
-					index: index ? index++ : undefined,
-					openerTabId: currentTab.id,
-				})
-			)
-		);
-	} catch (error: unknown) {
-		console.error(error);
-	}
+	await Promise.all(
+		urls.map(async (url) =>
+			browser.tabs.create({
+				url,
+				active,
+				index: index ? index++ : undefined,
+				openerTabId: currentTab.id,
+			})
+		)
+	);
 }

--- a/src/background/hints/watchNavigation.ts
+++ b/src/background/hints/watchNavigation.ts
@@ -49,14 +49,10 @@ export function watchNavigation() {
 		// We also send the frame id in the request as Safari is buggy sending
 		// messages to a specific frame and also sends them to other frames. This
 		// way we can check in the content script.
-		try {
-			await sendRequestToContent(
-				{ type: "onCompleted", frameId },
-				tabId,
-				frameId
-			);
-		} catch (error: unknown) {
-			console.error(error);
-		}
+		await sendRequestToContent(
+			{ type: "onCompleted", frameId },
+			tabId,
+			frameId
+		);
 	});
 }

--- a/src/background/utils/clipboard.ts
+++ b/src/background/utils/clipboard.ts
@@ -64,25 +64,19 @@ async function readClipboardSafari() {
 }
 
 async function readClipboardManifestV3(): Promise<string | undefined> {
-	try {
-		const hasDocument = await chrome.offscreen.hasDocument();
-		if (!hasDocument) {
-			await chrome.offscreen.createDocument({
-				url: urls.offscreenDocument.href,
-				reasons: [chrome.offscreen.Reason.CLIPBOARD],
-				justification: "Read the request from Talon from the clipboard",
-			});
-		}
-
-		return await chrome.runtime.sendMessage({
-			type: "read-clipboard",
-			target: "offscreen-doc",
+	const hasDocument = await chrome.offscreen.hasDocument();
+	if (!hasDocument) {
+		await chrome.offscreen.createDocument({
+			url: urls.offscreenDocument.href,
+			reasons: [chrome.offscreen.Reason.CLIPBOARD],
+			justification: "Read the request from Talon from the clipboard",
 		});
-	} catch (error: unknown) {
-		console.error(error);
 	}
 
-	return undefined;
+	return chrome.runtime.sendMessage({
+		type: "read-clipboard",
+		target: "offscreen-doc",
+	});
 }
 
 async function writeClipboardSafari(text: string) {
@@ -100,22 +94,18 @@ async function writeClipboardSafari(text: string) {
 }
 
 async function writeClipboardManifestV3(text: string) {
-	try {
-		const hasDocument = await chrome.offscreen.hasDocument();
-		if (!hasDocument) {
-			await chrome.offscreen.createDocument({
-				url: urls.offscreenDocument.href,
-				reasons: [chrome.offscreen.Reason.CLIPBOARD],
-				justification: "Write the response to Talon to the clipboard",
-			});
-		}
-
-		await chrome.runtime.sendMessage({
-			type: "copy-to-clipboard",
-			target: "offscreen-doc",
-			text,
+	const hasDocument = await chrome.offscreen.hasDocument();
+	if (!hasDocument) {
+		await chrome.offscreen.createDocument({
+			url: urls.offscreenDocument.href,
+			reasons: [chrome.offscreen.Reason.CLIPBOARD],
+			justification: "Write the response to Talon to the clipboard",
 		});
-	} catch (error: unknown) {
-		console.error(error);
 	}
+
+	await chrome.runtime.sendMessage({
+		type: "copy-to-clipboard",
+		target: "offscreen-doc",
+		text,
+	});
 }

--- a/src/background/utils/requestAndResponse.ts
+++ b/src/background/utils/requestAndResponse.ts
@@ -3,40 +3,40 @@ import type {
 	ResponseToTalon,
 } from "../../typings/RequestFromTalon";
 import { readClipboard, writeClipboard } from "./clipboard";
-import { notify } from "./notify";
 
 /**
  * Reads and parses the request from the clipboard.
  */
-export async function getRequest(): Promise<RequestFromTalon | undefined> {
+export async function getRequest() {
 	const clipText = await readClipboard();
-	let request: RequestFromTalon;
 
-	if (clipText) {
-		try {
-			request = JSON.parse(clipText) as RequestFromTalon;
-			// This is just to be extra safe
-			if (request.type !== "request") {
-				console.error(
-					'Error: The message present in the clipboard is not of type "request"'
-				);
-			}
-
-			return request;
-		} catch (error: unknown) {
-			// We already check that we are sending valid json in rango-talon, but
-			// just to be extra sure
-			if (error instanceof SyntaxError) {
-				console.error(error);
-			}
-		}
-	} else {
-		await notify("Unable to read the request present on the clipboard", {
-			type: "error",
-		});
+	if (clipText === "") {
+		throw new Error(
+			"Clipboard content is not a valid request. Clipboard is empty."
+		);
 	}
 
-	return undefined;
+	if (clipText === undefined) {
+		throw new Error("Unable to read clipboard content.");
+	}
+
+	try {
+		const request = JSON.parse(clipText) as RequestFromTalon;
+
+		if (request.type !== "request") {
+			throw new Error("Clipboard content is not a valid request.");
+		}
+
+		return request;
+	} catch (error: unknown) {
+		// We already check that we are sending valid json in rango-talon, but
+		// just to be extra sure
+		if (error instanceof SyntaxError) {
+			throw new SyntaxError("Clipboard content is not valid JSON.");
+		}
+
+		throw new Error("Unable to read clipboard content.");
+	}
 }
 
 /**


### PR DESCRIPTION
Simplify error handling in background script.  Rethrow a more descriptive error when possible. Have a global error handler to log to the console. Also notify the user when the error happens after a request.