### PR TITLE
Increase contrast for small text on settings page

### DIFF
--- a/src/settings/App.css
+++ b/src/settings/App.css
@@ -19,7 +19,7 @@ h1 {
 
 .small {
 	font-size: 0.85em;
-	opacity: 0.8;
+	opacity: 0.9;
 	margin-top: 0.4em;
 	margin-bottom: 0;
 	line-height: 1.4;


### PR DESCRIPTION
Change small text opacity from 80% to 90%. There isn't any impact for most people, but it increases the explainer text contrast for selected radio button from 4.4:1 to 5.53:1. Unselected radio buttons already had a contrast of 4.99:1, which is decent, but this changes the text so it will have a contrast of 6.46:1.