### PR TITLE
Update Toast.css with darker toastify text color

### DIFF
--- a/src/content/notify/Toast.css
+++ b/src/content/notify/Toast.css
@@ -52,7 +52,7 @@
 #rango-toast .Toastify__toast-body h2 {
 	border: 0 !important;
 	font-weight: bold !important;
-	color: var(--toastify-text-color-light) !important;
+	color: var(--toastify-color-dark) !important;
 }
 
 #rango-toast .Toastify__toast-body p {
@@ -69,7 +69,7 @@
 	padding: 0.2em 0.4em !important;
 	border-radius: 0.3em !important;
 	background-color: #e5e5e5 !important;
-	color: var(--toastify-text-color-light) !important;
+	color: var(--toastify-color-dark) !important;
 	text-shadow: unset !important;
 	font-size: inherit;
 }


### PR DESCRIPTION
Use toastify-color-dark instead of toastify-text-color-light for the footer code section (dismiss button) and the toast heading. This increases the contrast from 3.65:1 for the dismiss button to 14.87:1. For the heading (the text "Rango") the contrast increases from 4.6:1 to 18.73:1