### PR TITLE
Title decoration improvements

### DIFF
--- a/Rango/Rango for Safari.xcodeproj/project.pbxproj
+++ b/Rango/Rango for Safari.xcodeproj/project.pbxproj
@@ -7,26 +7,26 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6341EEDE2CB1456E00E5E710 /* whatsNew.e79f552b.css in Resources */ = {isa = PBXBuildFile; fileRef = 6341EEDD2CB1456E00E5E710 /* whatsNew.e79f552b.css */; };
-		6341EEDF2CB1456E00E5E710 /* icon.f5383140.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6341EED02CB1456E00E5E710 /* icon.f5383140.svg */; };
-		6341EEE02CB1456E00E5E710 /* settings.fce8ac3b.css in Resources */ = {isa = PBXBuildFile; fileRef = 6341EED92CB1456E00E5E710 /* settings.fce8ac3b.css */; };
-		6341EEE12CB1456E00E5E710 /* whatsNew.0b415932.html in Resources */ = {isa = PBXBuildFile; fileRef = 6341EEDC2CB1456E00E5E710 /* whatsNew.0b415932.html */; };
-		6341EEE22CB1456E00E5E710 /* icon.d20d9b97.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6341EECF2CB1456E00E5E710 /* icon.d20d9b97.svg */; };
-		6341EEE32CB1456E00E5E710 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 6341EED32CB1456E00E5E710 /* manifest.json */; };
-		6341EEE42CB1456E00E5E710 /* tippy.e52cbc8f.css in Resources */ = {isa = PBXBuildFile; fileRef = 6341EEDB2CB1456E00E5E710 /* tippy.e52cbc8f.css */; };
-		6341EEE52CB1456E00E5E710 /* content.b723d995.css in Resources */ = {isa = PBXBuildFile; fileRef = 6341EECC2CB1456E00E5E710 /* content.b723d995.css */; };
-		6341EEE62CB1456E00E5E710 /* content.d5600b6a.js in Resources */ = {isa = PBXBuildFile; fileRef = 6341EECD2CB1456E00E5E710 /* content.d5600b6a.js */; };
-		6341EEE72CB1456E00E5E710 /* settings.runtime.8301a841.js in Resources */ = {isa = PBXBuildFile; fileRef = 6341EEDA2CB1456E00E5E710 /* settings.runtime.8301a841.js */; };
-		6341EEE82CB1456E00E5E710 /* offscreen.c67d5c05.html in Resources */ = {isa = PBXBuildFile; fileRef = 6341EED52CB1456E00E5E710 /* offscreen.c67d5c05.html */; };
-		6341EEE92CB1456E00E5E710 /* offscreen.7cb32de6.js in Resources */ = {isa = PBXBuildFile; fileRef = 6341EED42CB1456E00E5E710 /* offscreen.7cb32de6.js */; };
-		6341EEEA2CB1456E00E5E710 /* background.runtime.45ec5fa6.js in Resources */ = {isa = PBXBuildFile; fileRef = 6341EECB2CB1456E00E5E710 /* background.runtime.45ec5fa6.js */; };
-		6341EEEB2CB1456E00E5E710 /* settings.a2733222.html in Resources */ = {isa = PBXBuildFile; fileRef = 6341EED72CB1456E00E5E710 /* settings.a2733222.html */; };
-		6341EEEC2CB1456E00E5E710 /* icon48.ace12d5e.png in Resources */ = {isa = PBXBuildFile; fileRef = 6341EED12CB1456E00E5E710 /* icon48.ace12d5e.png */; };
-		6341EEED2CB1456E00E5E710 /* settings.af26f380.js in Resources */ = {isa = PBXBuildFile; fileRef = 6341EED82CB1456E00E5E710 /* settings.af26f380.js */; };
-		6341EEEE2CB1456E00E5E710 /* icon-keyboard-clicking48.ac857c64.png in Resources */ = {isa = PBXBuildFile; fileRef = 6341EECE2CB1456E00E5E710 /* icon-keyboard-clicking48.ac857c64.png */; };
-		6341EEEF2CB1456E00E5E710 /* background.ec971b02.js in Resources */ = {isa = PBXBuildFile; fileRef = 6341EECA2CB1456E00E5E710 /* background.ec971b02.js */; };
-		6341EEF02CB1456E00E5E710 /* onboarding.b6199567.html in Resources */ = {isa = PBXBuildFile; fileRef = 6341EED62CB1456E00E5E710 /* onboarding.b6199567.html */; };
-		6341EEF12CB1456E00E5E710 /* icon128.8b6ee0ac.png in Resources */ = {isa = PBXBuildFile; fileRef = 6341EED22CB1456E00E5E710 /* icon128.8b6ee0ac.png */; };
+		63F487932D00407A00BE8269 /* offscreen.a61bb80b.html in Resources */ = {isa = PBXBuildFile; fileRef = 63F4878A2D00407A00BE8269 /* offscreen.a61bb80b.html */; };
+		63F487942D00407A00BE8269 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 63F487882D00407A00BE8269 /* manifest.json */; };
+		63F487952D00407A00BE8269 /* content.b723d995.css in Resources */ = {isa = PBXBuildFile; fileRef = 63F487812D00407A00BE8269 /* content.b723d995.css */; };
+		63F487962D00407A00BE8269 /* settings.db0fd559.html in Resources */ = {isa = PBXBuildFile; fileRef = 63F4878D2D00407A00BE8269 /* settings.db0fd559.html */; };
+		63F487972D00407A00BE8269 /* onboarding.b6199567.html in Resources */ = {isa = PBXBuildFile; fileRef = 63F4878B2D00407A00BE8269 /* onboarding.b6199567.html */; };
+		63F487982D00407A00BE8269 /* settings.runtime.12e0b2a1.js in Resources */ = {isa = PBXBuildFile; fileRef = 63F4878F2D00407A00BE8269 /* settings.runtime.12e0b2a1.js */; };
+		63F487992D00407A00BE8269 /* icon-keyboard-clicking48.ac857c64.png in Resources */ = {isa = PBXBuildFile; fileRef = 63F487832D00407A00BE8269 /* icon-keyboard-clicking48.ac857c64.png */; };
+		63F4879A2D00407A00BE8269 /* icon48.ace12d5e.png in Resources */ = {isa = PBXBuildFile; fileRef = 63F487862D00407A00BE8269 /* icon48.ace12d5e.png */; };
+		63F4879B2D00407A00BE8269 /* icon128.8b6ee0ac.png in Resources */ = {isa = PBXBuildFile; fileRef = 63F487872D00407A00BE8269 /* icon128.8b6ee0ac.png */; };
+		63F4879C2D00407A00BE8269 /* background.runtime.45ec5fa6.js in Resources */ = {isa = PBXBuildFile; fileRef = 63F487802D00407A00BE8269 /* background.runtime.45ec5fa6.js */; };
+		63F4879D2D00407A00BE8269 /* icon.d20d9b97.svg in Resources */ = {isa = PBXBuildFile; fileRef = 63F487842D00407A00BE8269 /* icon.d20d9b97.svg */; };
+		63F4879E2D00407A00BE8269 /* settings.e932913c.js in Resources */ = {isa = PBXBuildFile; fileRef = 63F4878E2D00407A00BE8269 /* settings.e932913c.js */; };
+		63F4879F2D00407A00BE8269 /* tippy.a5573b16.css in Resources */ = {isa = PBXBuildFile; fileRef = 63F487902D00407A00BE8269 /* tippy.a5573b16.css */; };
+		63F487A02D00407A00BE8269 /* settings.c8a6c321.css in Resources */ = {isa = PBXBuildFile; fileRef = 63F4878C2D00407A00BE8269 /* settings.c8a6c321.css */; };
+		63F487A12D00407A00BE8269 /* whatsNew.e79f552b.css in Resources */ = {isa = PBXBuildFile; fileRef = 63F487922D00407A00BE8269 /* whatsNew.e79f552b.css */; };
+		63F487A22D00407A00BE8269 /* content.d5600b6a.js in Resources */ = {isa = PBXBuildFile; fileRef = 63F487822D00407A00BE8269 /* content.d5600b6a.js */; };
+		63F487A32D00407A00BE8269 /* background.ec971b02.js in Resources */ = {isa = PBXBuildFile; fileRef = 63F4877F2D00407A00BE8269 /* background.ec971b02.js */; };
+		63F487A42D00407A00BE8269 /* icon.f5383140.svg in Resources */ = {isa = PBXBuildFile; fileRef = 63F487852D00407A00BE8269 /* icon.f5383140.svg */; };
+		63F487A52D00407A00BE8269 /* offscreen.18275b4d.js in Resources */ = {isa = PBXBuildFile; fileRef = 63F487892D00407A00BE8269 /* offscreen.18275b4d.js */; };
+		63F487A62D00407A00BE8269 /* whatsNew.0b415932.html in Resources */ = {isa = PBXBuildFile; fileRef = 63F487912D00407A00BE8269 /* whatsNew.0b415932.html */; };
 		E17BC8F8285E2315007EB9C6 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17BC8F7285E2315007EB9C6 /* Application.swift */; };
 		E1AEB977284D1D7800154974 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AEB976284D1D7800154974 /* AppDelegate.swift */; };
 		E1AEB97A284D1D7800154974 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E1AEB978284D1D7800154974 /* Main.storyboard */; };
@@ -65,26 +65,26 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		6341EECA2CB1456E00E5E710 /* background.ec971b02.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = background.ec971b02.js; sourceTree = "<group>"; };
-		6341EECB2CB1456E00E5E710 /* background.runtime.45ec5fa6.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = background.runtime.45ec5fa6.js; sourceTree = "<group>"; };
-		6341EECC2CB1456E00E5E710 /* content.b723d995.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = content.b723d995.css; sourceTree = "<group>"; };
-		6341EECD2CB1456E00E5E710 /* content.d5600b6a.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = content.d5600b6a.js; sourceTree = "<group>"; };
-		6341EECE2CB1456E00E5E710 /* icon-keyboard-clicking48.ac857c64.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-keyboard-clicking48.ac857c64.png"; sourceTree = "<group>"; };
-		6341EECF2CB1456E00E5E710 /* icon.d20d9b97.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = icon.d20d9b97.svg; sourceTree = "<group>"; };
-		6341EED02CB1456E00E5E710 /* icon.f5383140.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = icon.f5383140.svg; sourceTree = "<group>"; };
-		6341EED12CB1456E00E5E710 /* icon48.ace12d5e.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon48.ace12d5e.png; sourceTree = "<group>"; };
-		6341EED22CB1456E00E5E710 /* icon128.8b6ee0ac.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon128.8b6ee0ac.png; sourceTree = "<group>"; };
-		6341EED32CB1456E00E5E710 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
-		6341EED42CB1456E00E5E710 /* offscreen.7cb32de6.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = offscreen.7cb32de6.js; sourceTree = "<group>"; };
-		6341EED52CB1456E00E5E710 /* offscreen.c67d5c05.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = offscreen.c67d5c05.html; sourceTree = "<group>"; };
-		6341EED62CB1456E00E5E710 /* onboarding.b6199567.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = onboarding.b6199567.html; sourceTree = "<group>"; };
-		6341EED72CB1456E00E5E710 /* settings.a2733222.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = settings.a2733222.html; sourceTree = "<group>"; };
-		6341EED82CB1456E00E5E710 /* settings.af26f380.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = settings.af26f380.js; sourceTree = "<group>"; };
-		6341EED92CB1456E00E5E710 /* settings.fce8ac3b.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = settings.fce8ac3b.css; sourceTree = "<group>"; };
-		6341EEDA2CB1456E00E5E710 /* settings.runtime.8301a841.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = settings.runtime.8301a841.js; sourceTree = "<group>"; };
-		6341EEDB2CB1456E00E5E710 /* tippy.e52cbc8f.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = tippy.e52cbc8f.css; sourceTree = "<group>"; };
-		6341EEDC2CB1456E00E5E710 /* whatsNew.0b415932.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = whatsNew.0b415932.html; sourceTree = "<group>"; };
-		6341EEDD2CB1456E00E5E710 /* whatsNew.e79f552b.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = whatsNew.e79f552b.css; sourceTree = "<group>"; };
+		63F4877F2D00407A00BE8269 /* background.ec971b02.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = background.ec971b02.js; sourceTree = "<group>"; };
+		63F487802D00407A00BE8269 /* background.runtime.45ec5fa6.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = background.runtime.45ec5fa6.js; sourceTree = "<group>"; };
+		63F487812D00407A00BE8269 /* content.b723d995.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = content.b723d995.css; sourceTree = "<group>"; };
+		63F487822D00407A00BE8269 /* content.d5600b6a.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = content.d5600b6a.js; sourceTree = "<group>"; };
+		63F487832D00407A00BE8269 /* icon-keyboard-clicking48.ac857c64.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-keyboard-clicking48.ac857c64.png"; sourceTree = "<group>"; };
+		63F487842D00407A00BE8269 /* icon.d20d9b97.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = icon.d20d9b97.svg; sourceTree = "<group>"; };
+		63F487852D00407A00BE8269 /* icon.f5383140.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = icon.f5383140.svg; sourceTree = "<group>"; };
+		63F487862D00407A00BE8269 /* icon48.ace12d5e.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon48.ace12d5e.png; sourceTree = "<group>"; };
+		63F487872D00407A00BE8269 /* icon128.8b6ee0ac.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon128.8b6ee0ac.png; sourceTree = "<group>"; };
+		63F487882D00407A00BE8269 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		63F487892D00407A00BE8269 /* offscreen.18275b4d.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = offscreen.18275b4d.js; sourceTree = "<group>"; };
+		63F4878A2D00407A00BE8269 /* offscreen.a61bb80b.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = offscreen.a61bb80b.html; sourceTree = "<group>"; };
+		63F4878B2D00407A00BE8269 /* onboarding.b6199567.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = onboarding.b6199567.html; sourceTree = "<group>"; };
+		63F4878C2D00407A00BE8269 /* settings.c8a6c321.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = settings.c8a6c321.css; sourceTree = "<group>"; };
+		63F4878D2D00407A00BE8269 /* settings.db0fd559.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = settings.db0fd559.html; sourceTree = "<group>"; };
+		63F4878E2D00407A00BE8269 /* settings.e932913c.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = settings.e932913c.js; sourceTree = "<group>"; };
+		63F4878F2D00407A00BE8269 /* settings.runtime.12e0b2a1.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = settings.runtime.12e0b2a1.js; sourceTree = "<group>"; };
+		63F487902D00407A00BE8269 /* tippy.a5573b16.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = tippy.a5573b16.css; sourceTree = "<group>"; };
+		63F487912D00407A00BE8269 /* whatsNew.0b415932.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = whatsNew.0b415932.html; sourceTree = "<group>"; };
+		63F487922D00407A00BE8269 /* whatsNew.e79f552b.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = whatsNew.e79f552b.css; sourceTree = "<group>"; };
 		E17BC8F7285E2315007EB9C6 /* Application.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
 		E18784B1298EEFB50028A679 /* UserSpecific.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UserSpecific.xcconfig; sourceTree = "<group>"; };
 		E18784B2298EEFB50028A679 /* RangoVersion.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = RangoVersion.xcconfig; sourceTree = "<group>"; };
@@ -137,26 +137,26 @@
 		E18A7D4A298ED9B7000801AD /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				6341EECA2CB1456E00E5E710 /* background.ec971b02.js */,
-				6341EECB2CB1456E00E5E710 /* background.runtime.45ec5fa6.js */,
-				6341EECC2CB1456E00E5E710 /* content.b723d995.css */,
-				6341EECD2CB1456E00E5E710 /* content.d5600b6a.js */,
-				6341EECE2CB1456E00E5E710 /* icon-keyboard-clicking48.ac857c64.png */,
-				6341EECF2CB1456E00E5E710 /* icon.d20d9b97.svg */,
-				6341EED02CB1456E00E5E710 /* icon.f5383140.svg */,
-				6341EED12CB1456E00E5E710 /* icon48.ace12d5e.png */,
-				6341EED22CB1456E00E5E710 /* icon128.8b6ee0ac.png */,
-				6341EED32CB1456E00E5E710 /* manifest.json */,
-				6341EED42CB1456E00E5E710 /* offscreen.7cb32de6.js */,
-				6341EED52CB1456E00E5E710 /* offscreen.c67d5c05.html */,
-				6341EED62CB1456E00E5E710 /* onboarding.b6199567.html */,
-				6341EED72CB1456E00E5E710 /* settings.a2733222.html */,
-				6341EED82CB1456E00E5E710 /* settings.af26f380.js */,
-				6341EED92CB1456E00E5E710 /* settings.fce8ac3b.css */,
-				6341EEDA2CB1456E00E5E710 /* settings.runtime.8301a841.js */,
-				6341EEDB2CB1456E00E5E710 /* tippy.e52cbc8f.css */,
-				6341EEDC2CB1456E00E5E710 /* whatsNew.0b415932.html */,
-				6341EEDD2CB1456E00E5E710 /* whatsNew.e79f552b.css */,
+				63F4877F2D00407A00BE8269 /* background.ec971b02.js */,
+				63F487802D00407A00BE8269 /* background.runtime.45ec5fa6.js */,
+				63F487812D00407A00BE8269 /* content.b723d995.css */,
+				63F487822D00407A00BE8269 /* content.d5600b6a.js */,
+				63F487832D00407A00BE8269 /* icon-keyboard-clicking48.ac857c64.png */,
+				63F487842D00407A00BE8269 /* icon.d20d9b97.svg */,
+				63F487852D00407A00BE8269 /* icon.f5383140.svg */,
+				63F487862D00407A00BE8269 /* icon48.ace12d5e.png */,
+				63F487872D00407A00BE8269 /* icon128.8b6ee0ac.png */,
+				63F487882D00407A00BE8269 /* manifest.json */,
+				63F487892D00407A00BE8269 /* offscreen.18275b4d.js */,
+				63F4878A2D00407A00BE8269 /* offscreen.a61bb80b.html */,
+				63F4878B2D00407A00BE8269 /* onboarding.b6199567.html */,
+				63F4878C2D00407A00BE8269 /* settings.c8a6c321.css */,
+				63F4878D2D00407A00BE8269 /* settings.db0fd559.html */,
+				63F4878E2D00407A00BE8269 /* settings.e932913c.js */,
+				63F4878F2D00407A00BE8269 /* settings.runtime.12e0b2a1.js */,
+				63F487902D00407A00BE8269 /* tippy.a5573b16.css */,
+				63F487912D00407A00BE8269 /* whatsNew.0b415932.html */,
+				63F487922D00407A00BE8269 /* whatsNew.e79f552b.css */,
 			);
 			name = Resources;
 			path = "../../dist-mv2-safari";
@@ -328,26 +328,26 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6341EEDE2CB1456E00E5E710 /* whatsNew.e79f552b.css in Resources */,
-				6341EEDF2CB1456E00E5E710 /* icon.f5383140.svg in Resources */,
-				6341EEE02CB1456E00E5E710 /* settings.fce8ac3b.css in Resources */,
-				6341EEE12CB1456E00E5E710 /* whatsNew.0b415932.html in Resources */,
-				6341EEE22CB1456E00E5E710 /* icon.d20d9b97.svg in Resources */,
-				6341EEE32CB1456E00E5E710 /* manifest.json in Resources */,
-				6341EEE42CB1456E00E5E710 /* tippy.e52cbc8f.css in Resources */,
-				6341EEE52CB1456E00E5E710 /* content.b723d995.css in Resources */,
-				6341EEE62CB1456E00E5E710 /* content.d5600b6a.js in Resources */,
-				6341EEE72CB1456E00E5E710 /* settings.runtime.8301a841.js in Resources */,
-				6341EEE82CB1456E00E5E710 /* offscreen.c67d5c05.html in Resources */,
-				6341EEE92CB1456E00E5E710 /* offscreen.7cb32de6.js in Resources */,
-				6341EEEA2CB1456E00E5E710 /* background.runtime.45ec5fa6.js in Resources */,
-				6341EEEB2CB1456E00E5E710 /* settings.a2733222.html in Resources */,
-				6341EEEC2CB1456E00E5E710 /* icon48.ace12d5e.png in Resources */,
-				6341EEED2CB1456E00E5E710 /* settings.af26f380.js in Resources */,
-				6341EEEE2CB1456E00E5E710 /* icon-keyboard-clicking48.ac857c64.png in Resources */,
-				6341EEEF2CB1456E00E5E710 /* background.ec971b02.js in Resources */,
-				6341EEF02CB1456E00E5E710 /* onboarding.b6199567.html in Resources */,
-				6341EEF12CB1456E00E5E710 /* icon128.8b6ee0ac.png in Resources */,
+				63F487932D00407A00BE8269 /* offscreen.a61bb80b.html in Resources */,
+				63F487942D00407A00BE8269 /* manifest.json in Resources */,
+				63F487952D00407A00BE8269 /* content.b723d995.css in Resources */,
+				63F487962D00407A00BE8269 /* settings.db0fd559.html in Resources */,
+				63F487972D00407A00BE8269 /* onboarding.b6199567.html in Resources */,
+				63F487982D00407A00BE8269 /* settings.runtime.12e0b2a1.js in Resources */,
+				63F487992D00407A00BE8269 /* icon-keyboard-clicking48.ac857c64.png in Resources */,
+				63F4879A2D00407A00BE8269 /* icon48.ace12d5e.png in Resources */,
+				63F4879B2D00407A00BE8269 /* icon128.8b6ee0ac.png in Resources */,
+				63F4879C2D00407A00BE8269 /* background.runtime.45ec5fa6.js in Resources */,
+				63F4879D2D00407A00BE8269 /* icon.d20d9b97.svg in Resources */,
+				63F4879E2D00407A00BE8269 /* settings.e932913c.js in Resources */,
+				63F4879F2D00407A00BE8269 /* tippy.a5573b16.css in Resources */,
+				63F487A02D00407A00BE8269 /* settings.c8a6c321.css in Resources */,
+				63F487A12D00407A00BE8269 /* whatsNew.e79f552b.css in Resources */,
+				63F487A22D00407A00BE8269 /* content.d5600b6a.js in Resources */,
+				63F487A32D00407A00BE8269 /* background.ec971b02.js in Resources */,
+				63F487A42D00407A00BE8269 /* icon.f5383140.svg in Resources */,
+				63F487A52D00407A00BE8269 /* offscreen.18275b4d.js in Resources */,
+				63F487A62D00407A00BE8269 /* whatsNew.0b415932.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -293,3 +293,13 @@ async function contextMenusOnClicked({
 		await browser.runtime.openOptionsPage();
 	}
 }
+
+// =============================================================================
+// TAB UPDATED
+// =============================================================================
+browser.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
+	const { title, url } = changeInfo;
+	if (title ?? url) {
+		await sendMessage("tabDidUpdate", { title, url }, { tabId });
+	}
+});

--- a/src/background/messaging/backgroundMessageBroker.ts
+++ b/src/background/messaging/backgroundMessageBroker.ts
@@ -141,6 +141,25 @@ export async function sendMessage<K extends MessageWithoutTarget>(
 }
 
 /**
+ * Send a message to the content script. If the content script is unreachable or
+ * any other error occurs, this function will silently ignore the error and
+ * return `undefined`.
+ */
+export async function sendMessageSafe<K extends MessageWithoutTarget>(
+	messageId: K,
+	...args: HasRequiredData<K> extends true
+		? [data: MessageData<K>, destination?: Destination]
+		: [data?: MessageData<K>, destination?: Destination]
+) {
+	try {
+		return await sendMessage(messageId, ...args);
+	} catch {
+		// Silently ignore errors
+		return undefined;
+	}
+}
+
+/**
  * Send a message to all frames of the tab. It will return an object in the
  * shape `{ results, values }`. The `results` property is an array of objects
  * with the shape `{ frameId, value }`. The `values` property is just the

--- a/src/content/messaging/messageListeners.ts
+++ b/src/content/messaging/messageListeners.ts
@@ -51,7 +51,6 @@ import { updateHintsEnabled } from "../observe";
 import { setNavigationToggle } from "../settings/toggles";
 import {
 	getTitleBeforeDecoration,
-	removeDecorations,
 	updateTitleDecorations,
 } from "../setup/decorateTitle";
 import { getFirstWrapper, getTargetedWrappers } from "../wrappers/target";
@@ -117,10 +116,7 @@ export function addMessageListeners() {
 
 	onMessage("getTitleBeforeDecoration", getTitleBeforeDecoration);
 
-	onMessage("refreshTitleDecorations", async () => {
-		removeDecorations();
-		await updateTitleDecorations();
-	});
+	onMessage("refreshTitleDecorations", updateTitleDecorations);
 
 	onMessage("clickElement", async ({ target }) => {
 		const wrappers = await getTargetedWrappers(target);

--- a/src/content/messaging/messageListeners.ts
+++ b/src/content/messaging/messageListeners.ts
@@ -51,8 +51,8 @@ import { updateHintsEnabled } from "../observe";
 import { setNavigationToggle } from "../settings/toggles";
 import {
 	getTitleBeforeDecoration,
-	initTitleDecoration,
 	removeDecorations,
+	updateTitleDecorations,
 } from "../setup/decorateTitle";
 import { getFirstWrapper, getTargetedWrappers } from "../wrappers/target";
 import { reclaimLabels } from "../wrappers/wrappers";
@@ -119,7 +119,7 @@ export function addMessageListeners() {
 
 	onMessage("refreshTitleDecorations", async () => {
 		removeDecorations();
-		await initTitleDecoration();
+		await updateTitleDecorations();
 	});
 
 	onMessage("clickElement", async ({ target }) => {

--- a/src/content/setup/contentScriptContext.ts
+++ b/src/content/setup/contentScriptContext.ts
@@ -19,6 +19,10 @@ export function getTabId() {
 	return tabId;
 }
 
+/**
+ * Returns `true` if this is the current tab; that is, the active tab of the
+ * focused window.
+ */
 export async function isCurrentTab(): Promise<boolean> {
 	return sendMessage("isCurrentTab");
 }

--- a/src/content/setup/decorateTitle.ts
+++ b/src/content/setup/decorateTitle.ts
@@ -1,37 +1,50 @@
-import { throttle } from "lodash";
-import { sendMessage } from "../messaging/contentMessageBroker";
+import { onMessage, sendMessage } from "../messaging/contentMessageBroker";
 import { getSetting, onSettingChange } from "../settings/settingsManager";
 import { getToggles } from "../settings/toggles";
 import { isMainFrame } from "./contentScriptContext";
-
-// Settings
-let urlInTitle: boolean;
-let includeTabMarkers: boolean;
-let uppercaseTabMarkers: boolean;
 
 let lastUrlAdded: string | undefined;
 let titleBeforeDecoration: string | undefined;
 let titleAfterDecoration: string | undefined;
 
-async function getTitlePrefix() {
-	if (!includeTabMarkers) return "";
+/**
+ * Update the title decorations. Add the necessary decorations (tab marker and
+ * url) or remove them according to settings.
+ */
+export async function updateTitleDecorations() {
+	if (!isMainFrame()) return;
 
-	const tabMarker = await sendMessage("getTabMarker");
-	const marker = uppercaseTabMarkers ? tabMarker.toUpperCase() : tabMarker;
-
-	return `${marker} | `;
-}
-
-function getTitleSuffix() {
-	if (urlInTitle) {
-		return ` - ${window.location.href}`;
+	// Sometimes the document.title is modified by the page itself starting with
+	// the previous document.title. For example, in Bandcamp when the play button
+	// is clicked, "▶︎ " is added to the front of the title. After the track is
+	// stopped the first three characters of the title are removed.
+	if (
+		titleAfterDecoration &&
+		document.title !== titleAfterDecoration &&
+		document.title.includes(titleAfterDecoration)
+	) {
+		titleAfterDecoration = document.title;
+		return;
 	}
 
-	return "";
-}
+	const prefix = await getTitlePrefix();
+	const suffix = getTitleSuffix();
 
-export function getTitleBeforeDecoration() {
-	return titleBeforeDecoration ?? document.title;
+	// Remove decorations. Handle settings having changed and removing some
+	// decoration that is not needed anymore. Also make extra sure we don't
+	// duplicate the prefix or suffix. Prevents decorations from being added
+	// multiple times when the extension is updated and in some other difficult to
+	// reproduce situations.
+	removeDecorations(prefix);
+
+	if (document.title !== titleAfterDecoration) {
+		titleBeforeDecoration = document.title;
+	}
+
+	document.title = prefix + titleBeforeDecoration! + suffix;
+
+	if (suffix) lastUrlAdded = window.location.href;
+	if (prefix || suffix) titleAfterDecoration = document.title;
 }
 
 export function removeDecorations(prefix?: string) {
@@ -53,98 +66,46 @@ export function removeDecorations(prefix?: string) {
 	}
 }
 
-async function decorateTitle() {
-	// Sometimes the document.title is modified by the page itself starting with
-	// the previous document.title. For example, in basecamp when the play button
-	// is clicked, "▶︎ " is added to the front of the title. After the track is
-	// stopped the first three characters of the title are removed.
-	if (
-		titleAfterDecoration &&
-		document.title !== titleAfterDecoration &&
-		document.title.includes(titleAfterDecoration)
-	) {
-		titleAfterDecoration = document.title;
-		return;
-	}
+async function getTitlePrefix() {
+	if (!shouldIncludeTabMarkers()) return "";
 
-	const prefix = await getTitlePrefix();
-	const suffix = getTitleSuffix();
+	const tabMarker = await sendMessage("getTabMarker");
+	const marker = getSetting("uppercaseTabMarkers")
+		? tabMarker.toUpperCase()
+		: tabMarker;
 
-	// Make extra sure we don't duplicate the prefix or suffix. Prevents
-	// decorations from being added multiple times when the extension is updated
-	// and in some other difficult to reproduce situations.
-	removeDecorations(prefix);
-
-	if (document.title !== titleAfterDecoration) {
-		titleBeforeDecoration = document.title;
-	}
-
-	document.title = prefix + titleBeforeDecoration! + suffix;
-
-	if (suffix) {
-		lastUrlAdded = window.location.href;
-	}
-
-	titleAfterDecoration = document.title;
+	return `${marker} | `;
 }
 
-const throttledMutationCallback = throttle(async () => {
-	// We need to check if the url has changed every time there is a mutation.
-	// The URL could be changed using something like history.pushState and
-	// sometimes the title doesn't even change (issue #75).
-	if (
-		(urlInTitle && window.location.href !== lastUrlAdded) ||
-		document.title !== titleAfterDecoration
-	) {
-		await decorateTitle();
-	}
-}, 500);
-
-let mutationObserver: MutationObserver | undefined;
-
-export async function initTitleDecoration() {
-	if (!isMainFrame()) return;
-
-	const previousUrlInTitle = urlInTitle;
-	const previousIncludeTabMarkers = includeTabMarkers;
-
-	const globalHintsOff = getToggles().global;
-
-	urlInTitle = getSetting("urlInTitle");
-	includeTabMarkers =
-		getSetting("includeTabMarkers") &&
-		!(!globalHintsOff && getSetting("hideTabMarkersWithGlobalHintsOff"));
-	uppercaseTabMarkers = getSetting("uppercaseTabMarkers");
-
-	if (
-		(previousUrlInTitle && !urlInTitle) ||
-		(previousIncludeTabMarkers && !includeTabMarkers)
-	) {
-		removeDecorations();
+function getTitleSuffix() {
+	if (getSetting("urlInTitle")) {
+		return ` - ${window.location.href}`;
 	}
 
-	if (urlInTitle || includeTabMarkers) {
-		await decorateTitle();
-	} else {
-		mutationObserver?.disconnect();
-	}
-
-	if (urlInTitle) {
-		window.addEventListener("hashchange", async () => {
-			await decorateTitle();
-		});
-	}
-
-	if (urlInTitle || includeTabMarkers) {
-		mutationObserver ??= new MutationObserver(throttledMutationCallback);
-
-		mutationObserver.observe(document, {
-			attributes: true,
-			childList: true,
-			subtree: true,
-		});
-	}
+	return "";
 }
+
+export function getTitleBeforeDecoration() {
+	return titleBeforeDecoration ?? document.title;
+}
+
+function shouldIncludeTabMarkers() {
+	if (!getSetting("includeTabMarkers")) return false;
+
+	const globalHintsDisabled = !getToggles().global;
+	const hideMarkersWhenHintsOff = getSetting(
+		"hideTabMarkersWithGlobalHintsOff"
+	);
+
+	return !(hideMarkersWhenHintsOff && globalHintsDisabled);
+}
+
+onMessage("tabDidUpdate", async ({ title }) => {
+	// We ignore the instances after we decorate the title.
+	if (title && title === titleAfterDecoration) return;
+
+	await updateTitleDecorations();
+});
 
 onSettingChange(
 	[
@@ -153,11 +114,11 @@ onSettingChange(
 		"uppercaseTabMarkers",
 		"hideTabMarkersWithGlobalHintsOff",
 	],
-	initTitleDecoration
+	updateTitleDecorations
 );
 
 onSettingChange("hintsToggleGlobal", async () => {
 	if (getSetting("hideTabMarkersWithGlobalHintsOff")) {
-		await initTitleDecoration();
+		await updateTitleDecorations();
 	}
 });

--- a/src/content/setup/decorateTitle.ts
+++ b/src/content/setup/decorateTitle.ts
@@ -35,7 +35,7 @@ export async function updateTitleDecorations() {
 	// duplicate the prefix or suffix. Prevents decorations from being added
 	// multiple times when the extension is updated and in some other difficult to
 	// reproduce situations.
-	await removeDecorations();
+	document.title = await removeDecorations(document.title);
 
 	if (document.title !== titleAfterDecoration) {
 		titleBeforeDecoration = document.title;
@@ -47,26 +47,28 @@ export async function updateTitleDecorations() {
 	if (prefix || suffix) titleAfterDecoration = document.title;
 }
 
-export async function removeDecorations() {
+export async function removeDecorations(title: string) {
 	const prefix = await getTitlePrefix();
 
 	// This handles removing the title prefix when, for example, there is a hash
 	// change.
-	if (prefix && document.title.toLowerCase().startsWith(prefix.toLowerCase())) {
-		document.title = document.title.slice(prefix.length);
+	if (prefix && title.toLowerCase().startsWith(prefix.toLowerCase())) {
+		title = title.slice(prefix.length);
 	}
 
 	// This handles removing the prefix in some other circumstances. For example,
 	// when the prefix needs to be removed because of settings changes or the
 	// extension is updated.
 	if (!prefix) {
-		document.title = document.title.replace(/^[a-z]{1,2} \| /i, "");
+		title = title.replace(/^[a-z]{1,2} \| /i, "");
 	}
 
 	const possibleSuffix = ` - ${lastUrlAdded ?? window.location.href}`;
-	if (document.title.endsWith(possibleSuffix)) {
-		document.title = document.title.slice(0, -possibleSuffix.length);
+	if (title.endsWith(possibleSuffix)) {
+		title = title.slice(0, -possibleSuffix.length);
 	}
+
+	return title;
 }
 
 async function getTitlePrefix() {

--- a/src/content/setup/decorateTitle.ts
+++ b/src/content/setup/decorateTitle.ts
@@ -35,7 +35,7 @@ export async function updateTitleDecorations() {
 	// duplicate the prefix or suffix. Prevents decorations from being added
 	// multiple times when the extension is updated and in some other difficult to
 	// reproduce situations.
-	removeDecorations(prefix);
+	await removeDecorations();
 
 	if (document.title !== titleAfterDecoration) {
 		titleBeforeDecoration = document.title;
@@ -47,15 +47,18 @@ export async function updateTitleDecorations() {
 	if (prefix || suffix) titleAfterDecoration = document.title;
 }
 
-export function removeDecorations(prefix?: string) {
-	if (
-		prefix &&
-		(document.title.startsWith(prefix.toUpperCase()) ||
-			document.title.startsWith(prefix.toLowerCase()))
-	) {
+export async function removeDecorations() {
+	const prefix = await getTitlePrefix();
+
+	// This handles removing the title prefix when, for example, there is a hash
+	// change.
+	if (prefix && document.title.toLowerCase().startsWith(prefix.toLowerCase())) {
 		document.title = document.title.slice(prefix.length);
 	}
 
+	// This handles removing the prefix in some other circumstances. For example,
+	// when the prefix needs to be removed because of settings changes or the
+	// extension is updated.
 	if (!prefix) {
 		document.title = document.title.replace(/^[a-z]{1,2} \| /i, "");
 	}

--- a/src/content/setup/initContentScript.ts
+++ b/src/content/setup/initContentScript.ts
@@ -3,7 +3,7 @@ import { updateCustomSelectors } from "../hints/selectors";
 import observe from "../observe";
 import { getSetting, initSettingsManager } from "../settings/settingsManager";
 import { loadContentScriptContext } from "./contentScriptContext";
-import { initTitleDecoration } from "./decorateTitle";
+import { updateTitleDecorations } from "./decorateTitle";
 import { loadDevtoolsUtils } from "./devtoolsUtils";
 
 let initContentScriptPromise: Promise<void> | undefined;
@@ -20,7 +20,7 @@ export async function initContentScriptOrWait() {
 		await loadContentScriptContext();
 		await initSettingsManager();
 		await updateCustomSelectors();
-		await initTitleDecoration();
+		await updateTitleDecorations();
 		await observe();
 		if (getSetting("keyboardClicking")) initKeyboardClicking();
 	})();

--- a/src/typings/ProtocolMap.ts
+++ b/src/typings/ProtocolMap.ts
@@ -133,6 +133,7 @@ export type ContentBoundMessageMap = {
 	getTitleBeforeDecoration: () => string;
 	refreshTitleDecorations: () => void;
 	tabDidUpdate: (data: { title?: string; url?: string }) => void;
+	currentTabChanged: () => void;
 
 	// Notifications
 	displayToastNotification: (data: {

--- a/src/typings/ProtocolMap.ts
+++ b/src/typings/ProtocolMap.ts
@@ -132,6 +132,7 @@ export type ContentBoundMessageMap = {
 	// Tabs
 	getTitleBeforeDecoration: () => string;
 	refreshTitleDecorations: () => void;
+	tabDidUpdate: (data: { title?: string; url?: string }) => void;
 
 	// Notifications
 	displayToastNotification: (data: {


### PR DESCRIPTION
- Improve the logic for adding title decorators to make it easier to reason about them.
- Don't add decorations for the current tab if the original `document.title` is empty. Fixes #310