### PR TITLE
Replace instances of tab hint to tab marker

### DIFF
--- a/src/background/commands/upgradeCommand.ts
+++ b/src/background/commands/upgradeCommand.ts
@@ -8,7 +8,7 @@ import {
 	type ToggleLevel,
 } from "../../typings/Action";
 import { type Command, type CommandV2 } from "../../typings/Command";
-import { getTargetFromTabHints } from "../target/tabMarkers";
+import { getTargetFromTabMarkers } from "../target/tabMarkers";
 
 function upgradeAction(action: ActionV1): ActionV2<keyof ActionMap> {
 	const { type: name, target, ...rest } = action;
@@ -42,7 +42,7 @@ function upgradeAction(action: ActionV1): ActionV2<keyof ActionMap> {
 		case "unmuteTab": {
 			return {
 				name,
-				target: target ? getTargetFromTabHints(target) : undefined,
+				target: target ? getTargetFromTabMarkers(target) : undefined,
 			};
 		}
 

--- a/src/background/tabs/activateTab.ts
+++ b/src/background/tabs/activateTab.ts
@@ -3,7 +3,7 @@ import { type TabMark, type Target } from "../../typings/Target/Target";
 import { getTabIdsFromTarget } from "../target/tabMarkers";
 
 /**
- * Activate the tab with the given tab hint. If more than one tab hint is
+ * Activate the tab with the given tab marker. If more than one tab marker is
  * provided it will activate the given tabs as long as they belong to different
  * windows. It will focus the window of the first tab provided.
  */

--- a/src/background/tabs/createRelatedTabs.ts
+++ b/src/background/tabs/createRelatedTabs.ts
@@ -27,7 +27,6 @@ export async function createRelatedTabs(
 async function getNewTabIndex(tabId: number) {
 	const tab = await browser.tabs.get(tabId);
 	const newTabPosition = await retrieve("newTabPosition");
-	console.log("newTabPosition", newTabPosition);
 
 	switch (newTabPosition) {
 		case "relatedAfterCurrent": {

--- a/src/background/target/tabMarkers.ts
+++ b/src/background/target/tabMarkers.ts
@@ -1,7 +1,7 @@
 import { arrayToTarget } from "../../common/target/targetConversion";
 import {
-	type TabHintMark,
 	type TabMark,
+	type TabMarkerMark,
 	type Target,
 } from "../../typings/Target/Target";
 import { getTabIdForMarker } from "../tabs/tabMarkers";
@@ -18,6 +18,6 @@ export async function getTabIdsFromTarget(
 	return [await getTabIdForMarker(target.mark.value)];
 }
 
-export function getTargetFromTabHints(target: string[]) {
-	return arrayToTarget<TabHintMark>(target, "tabHint");
+export function getTargetFromTabMarkers(target: string[]) {
+	return arrayToTarget<TabMarkerMark>(target, "tabMarker");
 }

--- a/src/typings/Action.ts
+++ b/src/typings/Action.ts
@@ -1,6 +1,6 @@
 import {
 	type ElementMark,
-	type TabHintMark,
+	type TabMarkerMark,
 	type Target,
 } from "./Target/Target";
 
@@ -32,12 +32,12 @@ export type ActionMap = {
 	navigateToPreviousPage: void;
 
 	// Tabs
-	activateTab: { target: Target<TabHintMark> };
+	activateTab: { target: Target<TabMarkerMark> };
 	cloneCurrentTab: void;
 	closeNextTabsInWindow: { amount: number };
 	closeOtherTabsInWindow: void;
 	closePreviousTabsInWindow: { amount: number };
-	closeTab: { target: Target<TabHintMark> };
+	closeTab: { target: Target<TabMarkerMark> };
 	closeTabsLeftEndInWindow: { amount: number };
 	closeTabsRightEndInWindow: { amount: number };
 	closeTabsToTheLeftInWindow: void;
@@ -57,14 +57,14 @@ export type ActionMap = {
 	muteAllTabsWithSound: void;
 	muteCurrentTab: void;
 	muteNextTabWithSound: void;
-	muteTab: { target: Target<TabHintMark> };
+	muteTab: { target: Target<TabMarkerMark> };
 	openPageInNewTab: { url: string };
 	refreshTabMarkers: void;
 	toggleTabMarkers: void;
 	unmuteAllMutedTabs: void;
 	unmuteCurrentTab: void;
 	unmuteNextMutedTab: void;
-	unmuteTab: { target: Target<TabHintMark> };
+	unmuteTab: { target: Target<TabMarkerMark> };
 
 	// Keyboard Clicking
 	toggleKeyboardClicking: void;

--- a/src/typings/Target/Target.ts
+++ b/src/typings/Target/Target.ts
@@ -14,8 +14,8 @@ export type FuzzyTextElementMark = {
 	prioritizeViewport: boolean;
 };
 
-export type TabHintMark = {
-	type: "tabHint";
+export type TabMarkerMark = {
+	type: "tabMarker";
 	value: string;
 };
 
@@ -24,7 +24,7 @@ export type ElementMark =
 	| ElementReferenceMark
 	| FuzzyTextElementMark;
 
-export type TabMark = TabHintMark;
+export type TabMark = TabMarkerMark;
 
 export type Mark = ElementMark | TabMark;
 


### PR DESCRIPTION
After thinking for some time to rename `tab markers` to `tab hints` I have decided to stay with `tab marker`. I think it's easier to search in the codebase and less prone to confusion with element hints.