### PR TITLE
Remove unnecessary globalThis usage

### DIFF
--- a/e2e/decorateTitle.test.ts
+++ b/e2e/decorateTitle.test.ts
@@ -15,7 +15,7 @@ test("The URL and the tab marker are attached to the title", async () => {
 test("If something in the page changes and the URL changes it updates the title", async () => {
 	await page.evaluate(() => {
 		document.body.innerHTML = "<h1>New page</h1>";
-		globalThis.history.pushState({}, "", "new.html");
+		history.pushState({}, "", "new.html");
 	});
 
 	await sleep(200);

--- a/e2e/hintBackgroundColor.test.ts
+++ b/e2e/hintBackgroundColor.test.ts
@@ -9,7 +9,7 @@ describe("Background color", () => {
 	test("If the element doesn't have a background color set the background color of the hint will be white", async () => {
 		const backgroundColor = await page.$eval(".rango-hint", (hint) => {
 			const inner = hint.shadowRoot?.querySelector(".inner");
-			return globalThis.getComputedStyle(inner!).backgroundColor;
+			return getComputedStyle(inner!).backgroundColor;
 		});
 
 		expect(backgroundColor).toBe("rgb(255, 255, 255)");
@@ -21,7 +21,7 @@ describe("Background color", () => {
 
 		const backgroundColor = await page.$eval(".rango-hint", (hint) => {
 			const inner = hint.shadowRoot?.querySelector(".inner");
-			return globalThis.getComputedStyle(inner!).backgroundColor;
+			return getComputedStyle(inner!).backgroundColor;
 		});
 
 		expect(backgroundColor).toBe("rgb(0, 0, 128)");
@@ -38,7 +38,7 @@ describe("Background color", () => {
 
 		const backgroundColor = await page.$eval(".rango-hint", (hint) => {
 			const inner = hint.shadowRoot?.querySelector(".inner");
-			return globalThis.getComputedStyle(inner!).backgroundColor;
+			return getComputedStyle(inner!).backgroundColor;
 		});
 
 		expect(backgroundColor).toBe("rgb(0, 0, 64)");

--- a/e2e/keyboardClicking.test.ts
+++ b/e2e/keyboardClicking.test.ts
@@ -10,10 +10,7 @@ async function testKeyboardClickingHighlighting(frame?: Frame) {
 		".rango-hint",
 		(element) => {
 			const inner = element.shadowRoot!.querySelector(".inner")!;
-			return Number.parseInt(
-				globalThis.getComputedStyle(inner).borderWidth,
-				10
-			);
+			return Number.parseInt(getComputedStyle(inner).borderWidth, 10);
 		}
 	);
 
@@ -24,7 +21,7 @@ async function testKeyboardClickingHighlighting(frame?: Frame) {
 		".rango-hint",
 		(element) => {
 			const inner = element.shadowRoot!.querySelector(".inner")!;
-			const style = globalThis.getComputedStyle(inner);
+			const style = getComputedStyle(inner);
 			return [Number.parseInt(style.borderWidth, 10), style.borderColor];
 		}
 	);
@@ -38,7 +35,7 @@ async function testKeyboardClickingHighlighting(frame?: Frame) {
 	const [borderWidthAfterCompletion, borderColorAfterCompletion] =
 		await pageOrFrame.$eval(".rango-hint", (element) => {
 			const inner = element.shadowRoot!.querySelector(".inner")!;
-			const style = globalThis.getComputedStyle(inner);
+			const style = getComputedStyle(inner);
 			return [Number.parseInt(style.borderWidth, 10), style.borderColor];
 		});
 

--- a/e2e/overflowHintVisibility.test.ts
+++ b/e2e/overflowHintVisibility.test.ts
@@ -11,7 +11,7 @@ test("Hint outer div position should be relative for elements overflowing if the
 		"li:nth-child(20) > .rango-hint",
 		(shadowHost) => {
 			const outer = shadowHost.shadowRoot?.querySelector(".outer");
-			if (outer) return globalThis.getComputedStyle(outer).position;
+			if (outer) return getComputedStyle(outer).position;
 			return undefined;
 		}
 	);
@@ -29,7 +29,7 @@ test("Hint outer div position should be absolute for elements overflowing if the
 		"ul.relative > li:nth-child(20) > .rango-hint",
 		(shadowHost) => {
 			const outer = shadowHost.shadowRoot?.querySelector(".outer");
-			if (outer) return globalThis.getComputedStyle(outer).position;
+			if (outer) return getComputedStyle(outer).position;
 			return undefined;
 		}
 	);

--- a/e2e/scroll.test.ts
+++ b/e2e/scroll.test.ts
@@ -1,11 +1,11 @@
 /* eslint-disable max-nested-callbacks */
 import { type ElementHandle } from "puppeteer";
+import { getHintForElement } from "./utils/getHintForElement";
 import {
 	rangoCommandWithoutTarget,
 	rangoCommandWithTarget,
 } from "./utils/rangoCommands";
 import { sleep } from "./utils/testHelpers";
-import { getHintForElement } from "./utils/getHintForElement";
 
 jest.retryTimes(3);
 
@@ -25,7 +25,7 @@ async function getActionableHint(containerSelector: string, top = true) {
 		left: cLeft,
 	} = await $container!.evaluate((container) => {
 		const { top, right, bottom, left } = container.getBoundingClientRect();
-		if (globalThis.getComputedStyle(container).overflow === "visible") {
+		if (getComputedStyle(container).overflow === "visible") {
 			return {
 				top: 0,
 				right: document.documentElement.clientWidth,

--- a/src/content/actions/customScrollPositions.ts
+++ b/src/content/actions/customScrollPositions.ts
@@ -16,14 +16,13 @@ export async function storeScrollPosition(name: string) {
 
 	const scrollPositions = getSetting("customScrollPositions");
 	const scrollPositionsForCurrentPage =
-		scrollPositions.get(
-			globalThis.location.origin + globalThis.location.pathname
-		) ?? new Map<string, number>();
+		scrollPositions.get(location.origin + location.pathname) ??
+		new Map<string, number>();
 
 	scrollPositionsForCurrentPage.set(name, scrollTop);
 
 	scrollPositions.set(
-		globalThis.location.origin + globalThis.location.pathname,
+		location.origin + location.pathname,
 		scrollPositionsForCurrentPage
 	);
 	await store("customScrollPositions", scrollPositions);
@@ -36,9 +35,8 @@ export async function scrollToPosition(name: string) {
 
 	const scrollPositions = getSetting("customScrollPositions");
 	const scrollPositionsForCurrentPage =
-		scrollPositions.get(
-			globalThis.location.origin + globalThis.location.pathname
-		) ?? new Map<string, number>();
+		scrollPositions.get(location.origin + location.pathname) ??
+		new Map<string, number>();
 
 	const scrollPositionsArray = [...scrollPositionsForCurrentPage].map(
 		([name, number]) => ({ name, number })

--- a/src/content/actions/keyboardClicking.ts
+++ b/src/content/actions/keyboardClicking.ts
@@ -91,11 +91,11 @@ async function keydownHandler(event: KeyboardEvent) {
 }
 
 export function initKeyboardClicking() {
-	globalThis.addEventListener("keydown", keydownHandler, true);
+	addEventListener("keydown", keydownHandler, true);
 }
 
 function stopKeyboardClicking() {
-	globalThis.removeEventListener("keydown", keydownHandler, true);
+	removeEventListener("keydown", keydownHandler, true);
 }
 
 onSettingChange("keyboardClicking", async (keyboardClicking) => {

--- a/src/content/actions/references.ts
+++ b/src/content/actions/references.ts
@@ -66,7 +66,7 @@ export async function showReferences() {
 }
 
 export async function getReferences() {
-	const hostPattern = getHostPattern(globalThis.location.href);
+	const hostPattern = getHostPattern(location.href);
 	const references = getSetting("references");
 	const hostReferences =
 		references.get(hostPattern) ?? new Map<string, string>();

--- a/src/content/actions/scroll.ts
+++ b/src/content/actions/scroll.ts
@@ -22,9 +22,7 @@ export function getScrollBehavior() {
 	const scrollBehavior = getSetting("scrollBehavior");
 
 	if (scrollBehavior === "auto") {
-		const mediaQuery = globalThis.matchMedia(
-			"(prefers-reduced-motion: reduce)"
-		);
+		const mediaQuery = matchMedia("(prefers-reduced-motion: reduce)");
 		return !mediaQuery || mediaQuery.matches ? "instant" : "smooth";
 	}
 
@@ -73,7 +71,7 @@ function isScrollable(
 	direction: "horizontal" | "vertical"
 ) {
 	const { clientHeight, clientWidth, scrollHeight, scrollWidth } = element;
-	const { overflowX, overflowY } = globalThis.getComputedStyle(element);
+	const { overflowX, overflowY } = getComputedStyle(element);
 
 	if (direction === "horizontal" && clientWidth !== scrollWidth) {
 		if (element === document.documentElement) return true;
@@ -245,7 +243,7 @@ export function snapScroll(
 			}
 
 			const { position, display, visibility, opacity } =
-				globalThis.getComputedStyle(element);
+				getComputedStyle(element);
 
 			if (
 				display !== "none" &&
@@ -278,7 +276,7 @@ export function snapScroll(
 					}
 
 					const { position, display, visibility, opacity } =
-						globalThis.getComputedStyle(element);
+						getComputedStyle(element);
 
 					if (
 						display !== "none" &&

--- a/src/content/actions/setSelection.ts
+++ b/src/content/actions/setSelection.ts
@@ -21,7 +21,7 @@ export function setSelectionAtEdge(target: Element, atStart: boolean) {
 		range.selectNodeContents(targetNode);
 
 		range.collapse(atStart);
-		const selection = globalThis.getSelection();
+		const selection = getSelection();
 		assertDefined(selection);
 		selection.removeAllRanges();
 		selection.addRange(range);

--- a/src/content/dom/dispatchEvents.ts
+++ b/src/content/dom/dispatchEvents.ts
@@ -57,7 +57,7 @@ export function dispatchClick(element: Element): boolean {
 
 	if (element instanceof HTMLElement && isEditable(element)) {
 		window.focus();
-		const selection = globalThis.getSelection();
+		const selection = getSelection();
 
 		// This handles an issue where the element doesn't focus (Notion)
 		if (selection && !element.contains(selection.anchorNode)) {

--- a/src/content/dom/getUserScrollableContainer.ts
+++ b/src/content/dom/getUserScrollableContainer.ts
@@ -9,7 +9,7 @@ export function getUserScrollableContainer(
 	element: Element,
 	direction?: "vertical" | "horizontal"
 ) {
-	const elementPosition = globalThis.getComputedStyle(element).position;
+	const elementPosition = getComputedStyle(element).position;
 
 	const checked = [];
 	let current: Element | null = element;
@@ -18,8 +18,7 @@ export function getUserScrollableContainer(
 		const cached = containersCache.get(current);
 		if (cached) return cached;
 
-		const { position, overflowX, overflowY } =
-			globalThis.getComputedStyle(current);
+		const { position, overflowX, overflowY } = getComputedStyle(current);
 		const { scrollWidth, clientWidth, scrollHeight, clientHeight } = current;
 
 		if (position === "fixed") {

--- a/src/content/dom/isHintable.ts
+++ b/src/content/dom/isHintable.ts
@@ -67,7 +67,7 @@ function isRedundant(target: Element) {
 }
 
 export function isHintableExtra(target: Element): boolean {
-	const { cursor } = globalThis.getComputedStyle(target);
+	const { cursor } = getComputedStyle(target);
 
 	if (
 		(cursor === "pointer" ||

--- a/src/content/dom/isVisible.ts
+++ b/src/content/dom/isVisible.ts
@@ -1,7 +1,7 @@
 import { getBoundingClientRect } from "../hints/layoutCache";
 
 export function isVisible(element: Element): boolean {
-	const { visibility, opacity } = globalThis.getComputedStyle(element);
+	const { visibility, opacity } = getComputedStyle(element);
 	const { width, height } = getBoundingClientRect(element);
 
 	if (visibility === "hidden" || width < 5 || height < 5 || opacity === "0") {
@@ -29,7 +29,7 @@ export function isVisible(element: Element): boolean {
 	let counter = 0;
 
 	while (current && counter < 4) {
-		const { opacity } = globalThis.getComputedStyle(current);
+		const { opacity } = getComputedStyle(current);
 		if (opacity === "0") {
 			return false;
 		}

--- a/src/content/hints/Hint.ts
+++ b/src/content/hints/Hint.ts
@@ -148,7 +148,7 @@ function calculateZIndex(target: Element, hintOuter: HTMLDivElement) {
 	for (const descendant of descendants) {
 		if (createsStackingContext(descendant)) {
 			const descendantIndex = Number.parseInt(
-				globalThis.getComputedStyle(descendant).zIndex,
+				getComputedStyle(descendant).zIndex,
 				10
 			);
 			if (!Number.isNaN(descendantIndex)) {
@@ -164,7 +164,7 @@ function calculateZIndex(target: Element, hintOuter: HTMLDivElement) {
 
 		if (createsStackingContext(current)) {
 			const currentIndex = Number.parseInt(
-				globalThis.getComputedStyle(current).zIndex,
+				getComputedStyle(current).zIndex,
 				10
 			);
 			zIndex = Number.isNaN(currentIndex) ? 0 : currentIndex;
@@ -453,7 +453,7 @@ export class Hint {
 			} else {
 				const elementToGetColorFrom =
 					this.firstTextNodeDescendant?.parentElement;
-				let colorString = globalThis.getComputedStyle(
+				let colorString = getComputedStyle(
 					elementToGetColorFrom ?? this.target
 				).color;
 				colorString = colorString.startsWith("rgb")
@@ -536,7 +536,7 @@ export class Hint {
 
 		// We need to calculate this here the first time the hint is appended
 		if (this.wrapperRelative === undefined) {
-			const { display } = globalThis.getComputedStyle(
+			const { display } = getComputedStyle(
 				this.container instanceof HTMLElement
 					? this.container
 					: this.container.host
@@ -597,7 +597,7 @@ export class Hint {
 		// simple solution is to, when possible, place the hint as close to the
 		// hinted element as possible
 		if (this.elementToPositionHint instanceof Text) {
-			const { fontSize } = globalThis.getComputedStyle(
+			const { fontSize } = getComputedStyle(
 				this.elementToPositionHint.parentElement!
 			);
 			const fontSizePixels = Number.parseInt(fontSize, 10);

--- a/src/content/hints/color/getEffectiveBackgroundColor.ts
+++ b/src/content/hints/color/getEffectiveBackgroundColor.ts
@@ -28,7 +28,7 @@ function getAscendantRgb(element: Element) {
 	let current = element.parentElement;
 
 	while (current) {
-		const { backgroundColor } = globalThis.getComputedStyle(current);
+		const { backgroundColor } = getComputedStyle(current);
 
 		if (isRgb(backgroundColor)) {
 			return backgroundColor;
@@ -44,7 +44,7 @@ export function getEffectiveBackgroundColor(element: Element) {
 	let current: Element | null = element;
 
 	while (current) {
-		let { backgroundColor } = globalThis.getComputedStyle(current);
+		let { backgroundColor } = getComputedStyle(current);
 
 		if (!backgroundColor.startsWith("rgb")) {
 			backgroundColor = "rgb(255, 255, 255)";

--- a/src/content/hints/customHints/customHints.ts
+++ b/src/content/hints/customHints/customHints.ts
@@ -119,7 +119,7 @@ export async function customHintsReset() {
 	showExcludedHints = false;
 
 	await sendMessage("resetCustomSelectors", {
-		url: globalThis.location.href,
+		url: location.href,
 	});
 
 	await updateCustomSelectors();

--- a/src/content/hints/customHints/customSelectorsStaging.ts
+++ b/src/content/hints/customHints/customSelectorsStaging.ts
@@ -100,7 +100,7 @@ export function pickSelectorAlternative(options: {
  * @returns An array with the selectors that were added
  */
 export async function saveCustomSelectors() {
-	const pattern = getHostPattern(globalThis.location.href);
+	const pattern = getHostPattern(location.href);
 	const newCustomSelectors: CustomSelector[] = [];
 
 	for (const selector of includeSelectors) {
@@ -114,7 +114,7 @@ export async function saveCustomSelectors() {
 	// Even if both include and exclude are empty arrays we need to send the
 	// message to the background script to handle notifications
 	await sendMessage("storeCustomSelectors", {
-		url: globalThis.location.href,
+		url: location.href,
 		selectors: newCustomSelectors,
 	});
 

--- a/src/content/hints/layoutCache.ts
+++ b/src/content/hints/layoutCache.ts
@@ -153,7 +153,7 @@ export function cacheLayout(
 			offsetHeight:
 				element instanceof HTMLElement ? element.offsetHeight : undefined,
 		});
-		styles.set(element, globalThis.getComputedStyle(element));
+		styles.set(element, getComputedStyle(element));
 
 		if (element instanceof HTMLElement) {
 			offsetParents.set(element, element.offsetParent);
@@ -197,5 +197,5 @@ export function getClientDimensions(element: Element) {
 }
 
 export function getCachedStyle(element: Element) {
-	return styles.get(element) ?? globalThis.getComputedStyle(element);
+	return styles.get(element) ?? getComputedStyle(element);
 }

--- a/src/content/hints/positioning/getCustomNudge.ts
+++ b/src/content/hints/positioning/getCustomNudge.ts
@@ -12,7 +12,7 @@ customNudges.set("onenote.officeapps.live.com", [
  * @returns A tupple [left, top] with the pixel values that the hint needs to be nudged
  */
 export function getCustomNudge(element: Element): [number, number] {
-	const nudgesForHost = customNudges.get(globalThis.location.host);
+	const nudgesForHost = customNudges.get(location.host);
 
 	const nudgeForSelector = nudgesForHost?.find(([selector]) =>
 		element.matches(selector)

--- a/src/content/hints/positioning/getElementToPositionHint.ts
+++ b/src/content/hints/positioning/getElementToPositionHint.ts
@@ -82,7 +82,7 @@ function isImage(element: Element) {
 		(backgroundImage !== "none" ||
 			(Boolean(maskImage) && maskImage !== "none"));
 
-	const { content } = globalThis.getComputedStyle(element, ":before");
+	const { content } = getComputedStyle(element, ":before");
 	const isFontIcon =
 		element.tagName === "I" && content !== "none" && content !== "normal";
 

--- a/src/content/hints/selectors.ts
+++ b/src/content/hints/selectors.ts
@@ -37,7 +37,7 @@ export async function updateCustomSelectors() {
 	for (const { pattern, type, selector } of customSelectors.values()) {
 		const patternRe = new RegExp(pattern);
 
-		if (patternRe.test(globalThis.location.href)) {
+		if (patternRe.test(location.href)) {
 			if (type === "include") {
 				include.push(selector);
 			} else {

--- a/src/content/messaging/messageListeners.ts
+++ b/src/content/messaging/messageListeners.ts
@@ -205,11 +205,11 @@ export function addMessageListeners() {
 	});
 
 	onMessage("historyGoBack", () => {
-		globalThis.history.back();
+		history.back();
 	});
 
 	onMessage("historyGoForward", () => {
-		globalThis.history.forward();
+		history.forward();
 	});
 
 	onMessage("navigateToNextPage", navigateToNextPage);
@@ -217,7 +217,7 @@ export function addMessageListeners() {
 	onMessage("navigateToPreviousPage", navigateToPreviousPage);
 
 	onMessage("navigateToPageRoot", () => {
-		globalThis.location.href = "/";
+		location.href = "/";
 	});
 
 	onMessage("markHintsForInclusion", async ({ target }) => {

--- a/src/content/settings/settingsManager.ts
+++ b/src/content/settings/settingsManager.ts
@@ -26,7 +26,7 @@ export async function initSettingsManager() {
 			if (document.visibilityState === "visible") {
 				await handleSettingChange(changes);
 			} else {
-				globalThis.requestIdleCallback(async () => {
+				requestIdleCallback(async () => {
 					await handleSettingChange(changes);
 				});
 			}

--- a/src/content/settings/toggles.ts
+++ b/src/content/settings/toggles.ts
@@ -16,10 +16,8 @@ export function getToggles() {
 	} = getAllSettings();
 
 	const tabSwitch = hintsToggleTabs.get(getTabId());
-	const hostSwitch = hintsToggleHosts.get(globalThis.location.host);
-	const pathSwitch = hintsTogglePaths.get(
-		globalThis.location.origin + globalThis.location.pathname
-	);
+	const hostSwitch = hintsToggleHosts.get(location.host);
+	const pathSwitch = hintsTogglePaths.get(location.origin + location.pathname);
 
 	return {
 		computed:

--- a/src/content/setup/decorateTitle.ts
+++ b/src/content/setup/decorateTitle.ts
@@ -67,11 +67,11 @@ export async function updateTitleDecorations() {
 	document.title = prefix + lastUndecoratedTitle + suffix;
 	lastDecoratedTitle = document.title;
 
-	if (suffix) lastUrlAdded = globalThis.location.href;
+	if (suffix) lastUrlAdded = location.href;
 }
 
 async function removeDecorations(title: string) {
-	const possibleSuffix = ` - ${lastUrlAdded ?? globalThis.location.href}`;
+	const possibleSuffix = ` - ${lastUrlAdded ?? location.href}`;
 	if (title.endsWith(possibleSuffix)) {
 		title = title.slice(0, -possibleSuffix.length);
 	}
@@ -94,7 +94,7 @@ async function getTitlePrefix() {
 
 function getTitleSuffix() {
 	if (getSetting("urlInTitle")) {
-		return ` - ${globalThis.location.href}`;
+		return ` - ${location.href}`;
 	}
 
 	return "";

--- a/src/content/wrappers/ElementWrapper.ts
+++ b/src/content/wrappers/ElementWrapper.ts
@@ -466,8 +466,8 @@ export class ElementWrapper {
 				this.element.getAttribute("href") &&
 				// Issue #213: Open Discord's internal links in the same tab.
 				!(
-					globalThis.location.host === "discord.com" &&
-					globalThis.location.host === new URL(this.element.href).host
+					location.host === "discord.com" &&
+					location.host === new URL(this.element.href).host
 				)
 			) {
 				// In Firefox if we click a link with target="_blank" we get a popup


### PR DESCRIPTION
I got the idea from [Rule proposal: Avoid or prefer using globals as `globalThis.something` · Issue #2419 · sindresorhus/eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2419)