### PR TITLE
Implement range target for elements and tabs

### DIFF
--- a/src/background/messaging/backgroundMessageBroker.ts
+++ b/src/background/messaging/backgroundMessageBroker.ts
@@ -301,6 +301,27 @@ async function splitElementHintTargetByFrame(
 ) {
 	const hints = getTargetValues(target);
 	const stack = await getRequiredStack(tabId);
+
+	if (target.type === "range") {
+		const startFrameId = stack.assigned.get(target.start.mark.value);
+		if (startFrameId === undefined) {
+			throw new TargetError(`Couldn't find mark "${target.start.mark.value}".`);
+		}
+
+		const endFrameId = stack.assigned.get(target.end.mark.value);
+		if (endFrameId === undefined) {
+			throw new TargetError(`Couldn't find mark "${target.end.mark.value}".`);
+		}
+
+		if (startFrameId !== endFrameId) {
+			throw new TargetError(
+				`Marks "${target.start.mark.value}" and "${target.end.mark.value}" are in different frames.`
+			);
+		}
+
+		return new Map([[startFrameId, target]]);
+	}
+
 	const hintsByFrame = new Map<number, string[]>();
 
 	for (const hint of hints) {

--- a/src/background/messaging/backgroundMessageBroker.ts
+++ b/src/background/messaging/backgroundMessageBroker.ts
@@ -303,23 +303,27 @@ async function splitElementHintTargetByFrame(
 	const stack = await getRequiredStack(tabId);
 
 	if (target.type === "range") {
-		const startFrameId = stack.assigned.get(target.start.mark.value);
-		if (startFrameId === undefined) {
-			throw new TargetError(`Couldn't find mark "${target.start.mark.value}".`);
-		}
-
-		const endFrameId = stack.assigned.get(target.end.mark.value);
-		if (endFrameId === undefined) {
-			throw new TargetError(`Couldn't find mark "${target.end.mark.value}".`);
-		}
-
-		if (startFrameId !== endFrameId) {
+		const anchorFrameId = stack.assigned.get(target.anchor.mark.value);
+		if (anchorFrameId === undefined) {
 			throw new TargetError(
-				`Marks "${target.start.mark.value}" and "${target.end.mark.value}" are in different frames.`
+				`Couldn't find mark "${target.anchor.mark.value}".`
 			);
 		}
 
-		return new Map([[startFrameId, target]]);
+		const activeFrameId = stack.assigned.get(target.active.mark.value);
+		if (activeFrameId === undefined) {
+			throw new TargetError(
+				`Couldn't find mark "${target.active.mark.value}".`
+			);
+		}
+
+		if (anchorFrameId !== activeFrameId) {
+			throw new TargetError(
+				`Marks "${target.anchor.mark.value}" and "${target.active.mark.value}" are in different frames.`
+			);
+		}
+
+		return new Map([[anchorFrameId, target]]);
 	}
 
 	const hintsByFrame = new Map<number, string[]>();

--- a/src/background/target/tabMarkers.ts
+++ b/src/background/target/tabMarkers.ts
@@ -17,27 +17,25 @@ export async function getTabIdsFromTarget(
 	}
 
 	if (target.type === "range") {
-		const startTabId = await getTabIdForMarker(target.start.mark.value);
-		const endTabId = await getTabIdForMarker(target.end.mark.value);
+		const anchorTabId = await getTabIdForMarker(target.anchor.mark.value);
+		const activeTabId = await getTabIdForMarker(target.active.mark.value);
 
-		const startTab = await browser.tabs.get(startTabId);
-		const endTab = await browser.tabs.get(endTabId);
+		const anchorTab = await browser.tabs.get(anchorTabId);
+		const activeTab = await browser.tabs.get(activeTabId);
 
-		if (startTab.windowId !== endTab.windowId) {
-			throw new Error("Start and end tabs are in different windows.");
+		if (anchorTab.windowId !== activeTab.windowId) {
+			throw new Error("Anchor and active tabs are in different windows.");
 		}
 
-		const firstTab = startTab.index < endTab.index ? startTab : endTab;
-		const lastTab = startTab.index < endTab.index ? endTab : startTab;
+		const startTab = anchorTab.index < activeTab.index ? anchorTab : activeTab;
+		const endTab = anchorTab.index < activeTab.index ? activeTab : anchorTab;
 
 		const tabsInWindow = await browser.tabs.query({
 			windowId: startTab.windowId,
 		});
 
 		return tabsInWindow
-			.filter(
-				(tab) => tab.index >= firstTab.index && tab.index <= lastTab.index
-			)
+			.filter((tab) => tab.index >= startTab.index && tab.index <= endTab.index)
 			.map((tab) => tab.id!);
 	}
 

--- a/src/background/target/tabMarkers.ts
+++ b/src/background/target/tabMarkers.ts
@@ -1,3 +1,4 @@
+import browser from "webextension-polyfill";
 import { arrayToTarget } from "../../common/target/targetConversion";
 import {
 	type TabMark,
@@ -13,6 +14,31 @@ export async function getTabIdsFromTarget(
 		return Promise.all(
 			target.items.map(async (item) => getTabIdForMarker(item.mark.value))
 		);
+	}
+
+	if (target.type === "range") {
+		const startTabId = await getTabIdForMarker(target.start.mark.value);
+		const endTabId = await getTabIdForMarker(target.end.mark.value);
+
+		const startTab = await browser.tabs.get(startTabId);
+		const endTab = await browser.tabs.get(endTabId);
+
+		if (startTab.windowId !== endTab.windowId) {
+			throw new Error("Start and end tabs are in different windows.");
+		}
+
+		const firstTab = startTab.index < endTab.index ? startTab : endTab;
+		const lastTab = startTab.index < endTab.index ? endTab : startTab;
+
+		const tabsInWindow = await browser.tabs.query({
+			windowId: startTab.windowId,
+		});
+
+		return tabsInWindow
+			.filter(
+				(tab) => tab.index >= firstTab.index && tab.index <= lastTab.index
+			)
+			.map((tab) => tab.id!);
 	}
 
 	return [await getTabIdForMarker(target.mark.value)];

--- a/src/common/target/targetConversion.ts
+++ b/src/common/target/targetConversion.ts
@@ -42,7 +42,7 @@ export function getTargetMarkType<T extends Mark>(
 	}
 
 	if (target.type === "range") {
-		return target.start.mark.type;
+		return target.anchor.mark.type;
 	}
 
 	const firstItem = target.items[0];
@@ -60,7 +60,7 @@ export function getTargetValues<T extends Mark>(target: Target<T>) {
 	}
 
 	if (target.type === "range") {
-		return [target.start.mark.value, target.end.mark.value];
+		return [target.anchor.mark.value, target.active.mark.value];
 	}
 
 	return target.items.map((item) => item.mark.value);
@@ -83,7 +83,7 @@ export function getPrioritizeViewportValue<T extends FuzzyTextElementMark>(
 	}
 
 	if (target.type === "range") {
-		return target.start.mark.prioritizeViewport;
+		return target.anchor.mark.prioritizeViewport;
 	}
 
 	return target.items[0]!.mark.prioritizeViewport;

--- a/src/common/target/targetConversion.ts
+++ b/src/common/target/targetConversion.ts
@@ -41,6 +41,10 @@ export function getTargetMarkType<T extends Mark>(
 		return target.mark.type;
 	}
 
+	if (target.type === "range") {
+		return target.start.mark.type;
+	}
+
 	const firstItem = target.items[0];
 
 	if (!firstItem) {
@@ -53,6 +57,10 @@ export function getTargetMarkType<T extends Mark>(
 export function getTargetValues<T extends Mark>(target: Target<T>) {
 	if (target.type === "primitive") {
 		return [target.mark.value];
+	}
+
+	if (target.type === "range") {
+		return [target.start.mark.value, target.end.mark.value];
 	}
 
 	return target.items.map((item) => item.mark.value);
@@ -72,6 +80,10 @@ export function getPrioritizeViewportValue<T extends FuzzyTextElementMark>(
 ) {
 	if (target.type === "primitive") {
 		return target.mark.prioritizeViewport;
+	}
+
+	if (target.type === "range") {
+		return target.start.mark.prioritizeViewport;
 	}
 
 	return target.items[0]!.mark.prioritizeViewport;

--- a/src/content/dom/getSimilarElementsBetween.ts
+++ b/src/content/dom/getSimilarElementsBetween.ts
@@ -1,0 +1,113 @@
+/**
+ * Get all elements between two elements that are similar. Elements are considered similar if
+ * they have the same tag name and their classes are similar.
+ *
+ * @param start - The start element.
+ * @param end - The end element.
+ * @returns An array of all elements between the start and end element that are similar.
+ */
+export function getSimilarElementsInRange(
+	start: Element,
+	end: Element
+): Element[] {
+	const commonAncestor = findCommonAncestor(start, end);
+	if (!commonAncestor) return [];
+
+	// Get all elements between start and end that are similar
+	const elements = getAllElementsBetween(start, end, commonAncestor);
+	return elements.filter(
+		(element) =>
+			isSimilarElement(element, start) || isSimilarElement(element, end)
+	);
+}
+
+function findCommonAncestor(element1: Element, element2: Element) {
+	const ancestors1 = getAncestors(element1);
+	const ancestors2 = getAncestors(element2);
+
+	return ancestors1.find((ancestor) => ancestors2.includes(ancestor));
+}
+
+function getAncestors(element: Element) {
+	const ancestors: Element[] = [];
+	let current: Element | null = element;
+
+	while (current) {
+		ancestors.push(current);
+		current = current.parentElement;
+	}
+
+	return ancestors;
+}
+
+function getAllElementsBetween(
+	start: Element,
+	end: Element,
+	commonAncestor: Element
+) {
+	const walker = document.createTreeWalker(
+		commonAncestor,
+		NodeFilter.SHOW_ELEMENT,
+		null
+	);
+
+	const [firstElement, lastElement] = sortByDocumentPosition([start, end]);
+
+	const elements: Element[] = [];
+	let currentNode = walker.currentNode as Element;
+	let foundFirst = false;
+	let foundLast = false;
+
+	// Walk through all elements in DOM order starting with the common ancestor.
+	// Push elements to the array if they are between the first and last element.
+	while (currentNode && !foundLast) {
+		if (currentNode === firstElement) {
+			foundFirst = true;
+		}
+
+		if (foundFirst) {
+			elements.push(currentNode);
+		}
+
+		if (currentNode === lastElement) {
+			foundLast = true;
+		}
+
+		currentNode = walker.nextNode() as Element;
+	}
+
+	// If we didn't find both elements, return empty array
+	if (!foundFirst || !foundLast) {
+		return [];
+	}
+
+	return elements;
+}
+
+function sortByDocumentPosition(elements: Element[]) {
+	return elements.sort((a, b) => {
+		// eslint-disable-next-line no-bitwise
+		return a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING
+			? -1
+			: 1;
+	});
+}
+
+function isSimilarElement(element1: Element, element2: Element) {
+	if (element1.tagName !== element2.tagName) return false;
+
+	const classes1 = Array.from(element1.classList);
+	const classes2 = Array.from(element2.classList);
+
+	// If neither element has classes, they're considered similar
+	if (classes1.length === 0 && classes2.length === 0) return true;
+
+	const commonClasses = classes1.filter((cls) => classes2.includes(cls));
+
+	// Calculate similarity ratio based on the element with fewer classes
+	const minClassCount = Math.min(classes1.length, classes2.length);
+	const similarityRatio = commonClasses.length / minClassCount;
+
+	// Consider elements similar if they share at least 80% of their classes
+	return similarityRatio >= 0.8;
+}

--- a/src/content/dom/getSimilarElementsBetween.ts
+++ b/src/content/dom/getSimilarElementsBetween.ts
@@ -2,22 +2,22 @@
  * Get all elements between two elements that are similar. Elements are considered similar if
  * they have the same tag name and their classes are similar.
  *
- * @param start - The start element.
- * @param end - The end element.
- * @returns An array of all elements between the start and end element that are similar.
+ * @param anchor - The anchor element.
+ * @param active - The active element.
+ * @returns An array of all elements between the anchor and active element that are similar.
  */
 export function getSimilarElementsInRange(
-	start: Element,
-	end: Element
+	anchor: Element,
+	active: Element
 ): Element[] {
-	const commonAncestor = findCommonAncestor(start, end);
+	const commonAncestor = findCommonAncestor(anchor, active);
 	if (!commonAncestor) return [];
 
 	// Get all elements between start and end that are similar
-	const elements = getAllElementsBetween(start, end, commonAncestor);
+	const elements = getAllElementsBetween(anchor, active, commonAncestor);
 	return elements.filter(
 		(element) =>
-			isSimilarElement(element, start) || isSimilarElement(element, end)
+			isSimilarElement(element, anchor) || isSimilarElement(element, active)
 	);
 }
 
@@ -41,8 +41,8 @@ function getAncestors(element: Element) {
 }
 
 function getAllElementsBetween(
-	start: Element,
-	end: Element,
+	anchor: Element,
+	active: Element,
 	commonAncestor: Element
 ) {
 	const walker = document.createTreeWalker(
@@ -51,7 +51,7 @@ function getAllElementsBetween(
 		null
 	);
 
-	const [firstElement, lastElement] = sortByDocumentPosition([start, end]);
+	const [start, end] = sortByDocumentPosition([anchor, active]);
 
 	const elements: Element[] = [];
 	let currentNode = walker.currentNode as Element;
@@ -61,7 +61,7 @@ function getAllElementsBetween(
 	// Walk through all elements in DOM order starting with the common ancestor.
 	// Push elements to the array if they are between the first and last element.
 	while (currentNode && !foundLast) {
-		if (currentNode === firstElement) {
+		if (currentNode === start) {
 			foundFirst = true;
 		}
 
@@ -69,7 +69,7 @@ function getAllElementsBetween(
 			elements.push(currentNode);
 		}
 
-		if (currentNode === lastElement) {
+		if (currentNode === end) {
 			foundLast = true;
 		}
 

--- a/src/content/wrappers/target.ts
+++ b/src/content/wrappers/target.ts
@@ -3,24 +3,32 @@ import {
 	getTargetValues,
 } from "../../common/target/targetConversion";
 import { TargetError } from "../../common/target/TargetError";
-import { type ElementMark, type Target } from "../../typings/Target/Target";
+import {
+	type ElementMark,
+	type RangeTarget,
+	type Target,
+} from "../../typings/Target/Target";
+import { isDefined } from "../../typings/TypingUtils";
 import { getTextMatchedElement } from "../actions/matchElementByText";
 import { getReferences } from "../actions/references";
 import { getElementFromSelector } from "../dom/getElementFromSelector";
+import { getSimilarElementsInRange } from "../dom/getSimilarElementsBetween";
 import { assertWrappersIntersectViewport } from "./assertIntersectingWrappers";
-import { type ElementWrapper, getOrCreateWrapper } from "./ElementWrapper";
+import { getOrCreateWrapper } from "./ElementWrapper";
 import { setLastTargetedWrapper } from "./lastTargetedWrapper";
 import { getWrapper } from "./wrappers";
 
 export async function getTargetedWrappers(target: Target<ElementMark>) {
-	const type = getTargetMarkType(target);
+	const markType = getTargetMarkType(target);
 
 	const wrappers = await getWrappersForTarget(target);
 
 	const lastWrapper = wrappers.at(-1);
 	if (lastWrapper) setLastTargetedWrapper(lastWrapper);
 
-	if (type === "elementHint") assertWrappersIntersectViewport(wrappers);
+	if (markType === "elementHint" && target.type !== "range") {
+		assertWrappersIntersectViewport(wrappers);
+	}
 
 	for (const wrapper of wrappers) wrapper.hint?.flash();
 
@@ -34,10 +42,19 @@ export async function getFirstWrapper(target: Target<ElementMark>) {
 }
 
 async function getWrappersForTarget(target: Target<ElementMark>) {
-	const values = getTargetValues(target);
-	const type = getTargetMarkType(target);
+	const markType = getTargetMarkType(target);
 
-	switch (type) {
+	if (target.type === "range") {
+		if (markType !== "elementHint") {
+			throw new Error("Range targets are only supported for element hints.");
+		}
+
+		return getRangeWrappers(target).filter((wrapper) => wrapper.isHintable);
+	}
+
+	const values = getTargetValues(target);
+
+	switch (markType) {
 		case "elementHint": {
 			return values.map((hint) => {
 				const wrapper = getWrapper(hint);
@@ -60,9 +77,7 @@ async function getWrappersForTarget(target: Target<ElementMark>) {
 					return element ? getOrCreateWrapper(element, false) : undefined;
 				})
 			);
-			return wrappers.filter(
-				(wrapper): wrapper is ElementWrapper => wrapper !== undefined
-			);
+			return wrappers.filter((element) => isDefined(element));
 		}
 
 		case "fuzzyText": {
@@ -73,7 +88,32 @@ async function getWrappersForTarget(target: Target<ElementMark>) {
 
 					return getOrCreateWrapper(element, false);
 				})
-				.filter((wrapper): wrapper is ElementWrapper => wrapper !== undefined);
+				.filter((element) => isDefined(element));
 		}
 	}
+}
+
+function getRangeWrappers(target: RangeTarget<ElementMark>) {
+	const start = target.start.mark.value;
+	const end = target.end.mark.value;
+
+	const startWrapper = getWrapper(start);
+	const endWrapper = getWrapper(end);
+
+	if (!startWrapper?.isIntersectingViewport) {
+		throw new TargetError(`Couldn't find mark "${start}" in viewport.`);
+	}
+
+	if (!endWrapper?.isIntersectingViewport) {
+		throw new TargetError(`Couldn't find mark "${end}" in viewport.`);
+	}
+
+	const elements = getSimilarElementsInRange(
+		startWrapper.element,
+		endWrapper.element
+	);
+
+	return elements
+		.map((element) => getWrapper(element))
+		.filter((element) => isDefined(element));
 }

--- a/src/content/wrappers/target.ts
+++ b/src/content/wrappers/target.ts
@@ -94,23 +94,23 @@ async function getWrappersForTarget(target: Target<ElementMark>) {
 }
 
 function getRangeWrappers(target: RangeTarget<ElementMark>) {
-	const start = target.start.mark.value;
-	const end = target.end.mark.value;
+	const anchor = target.anchor.mark.value;
+	const active = target.active.mark.value;
 
-	const startWrapper = getWrapper(start);
-	const endWrapper = getWrapper(end);
+	const anchorWrapper = getWrapper(anchor);
+	const activeWrapper = getWrapper(active);
 
-	if (!startWrapper?.isIntersectingViewport) {
-		throw new TargetError(`Couldn't find mark "${start}" in viewport.`);
+	if (!anchorWrapper?.isIntersectingViewport) {
+		throw new TargetError(`Couldn't find mark "${anchor}" in viewport.`);
 	}
 
-	if (!endWrapper?.isIntersectingViewport) {
-		throw new TargetError(`Couldn't find mark "${end}" in viewport.`);
+	if (!activeWrapper?.isIntersectingViewport) {
+		throw new TargetError(`Couldn't find mark "${active}" in viewport.`);
 	}
 
 	const elements = getSimilarElementsInRange(
-		startWrapper.element,
-		endWrapper.element
+		anchorWrapper.element,
+		activeWrapper.element
 	);
 
 	return elements

--- a/src/typings/Target/Target.ts
+++ b/src/typings/Target/Target.ts
@@ -38,7 +38,16 @@ type ListTarget<T extends Mark> = {
 	items: Array<PrimitiveTarget<T>>;
 };
 
-export type Target<T extends Mark> = ListTarget<T> | PrimitiveTarget<T>;
+export type RangeTarget<T extends Mark> = {
+	type: "range";
+	start: PrimitiveTarget<T>;
+	end: PrimitiveTarget<T>;
+};
+
+export type Target<T extends Mark> =
+	| ListTarget<T>
+	| PrimitiveTarget<T>
+	| RangeTarget<T>;
 
 export function assertPrimitiveTarget<T extends Mark>(
 	target: Target<T>

--- a/src/typings/Target/Target.ts
+++ b/src/typings/Target/Target.ts
@@ -40,8 +40,8 @@ type ListTarget<T extends Mark> = {
 
 export type RangeTarget<T extends Mark> = {
 	type: "range";
-	start: PrimitiveTarget<T>;
-	end: PrimitiveTarget<T>;
+	anchor: PrimitiveTarget<T>;
+	active: PrimitiveTarget<T>;
 };
 
 export type Target<T extends Mark> =

--- a/src/typings/TypingUtils.ts
+++ b/src/typings/TypingUtils.ts
@@ -28,3 +28,7 @@ export function hasPropertyDisabled(
 export function isHtmlElement(element: Element): element is HTMLElement {
 	return element instanceof HTMLElement;
 }
+
+export function isDefined<T>(value: T | null | undefined): value is T {
+	return value !== null && value !== undefined;
+}


### PR DESCRIPTION
This allows us to select a range of elements or tabs by just saying the first and last items.

In the rango-talon side I have settled for the connector `until` and not `past` like in cursorless. The reason for this is using past is too prone to misrecognitions. For example, `cap past fine` would be often recognized as `cap paste fine` which would execute the community commands `cap paste` and `fine`. Some people have also changed `paste that` for `paste it` and this was also being triggered often when trying to execute a command with a range.