### PR TITLE
Fix some errors when getting tab id

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -15,7 +15,7 @@ import {
 import { addMessageListeners } from "./messaging/messageListeners";
 import { toggleKeyboardClicking } from "./settings/keyboardClicking";
 import { setTabLastSounded } from "./tabs/focusTabBySound";
-import { getCurrentTab } from "./tabs/getCurrentTab";
+import { getCurrentTab, getRequiredCurrentTab } from "./tabs/getCurrentTab";
 import { initTabMarkers } from "./tabs/tabMarkers";
 import { trackRecentTabs } from "./tabs/trackRecentTabs";
 import { browserAction, setBrowserActionIcon } from "./utils/browserAction";
@@ -286,7 +286,7 @@ async function contextMenusOnClicked({
 
 	if (menuItemId === "add-keys-to-exclude") {
 		const keysToExclude = await retrieve("keysToExclude");
-		const tab = await getCurrentTab();
+		const tab = await getRequiredCurrentTab();
 		const hostPattern = tab.url && getHostPattern(tab.url);
 		const keysToExcludeForHost = keysToExclude.find(
 			([pattern]) => pattern === hostPattern
@@ -311,7 +311,7 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
 	}
 });
 
-let lastCurrentTab: browser.Tabs.Tab;
+let lastCurrentTab: browser.Tabs.Tab | undefined;
 
 (async () => {
 	try {
@@ -327,7 +327,7 @@ browser.tabs.onActivated.addListener(async (activeInfo) => {
 
 		// If the window also changes the update will be handled by the
 		// `windows.onFocusChanged` listener.
-		if (windowId !== lastCurrentTab.windowId) return;
+		if (windowId !== lastCurrentTab?.windowId) return;
 
 		await sendMessageSafe("currentTabChanged", undefined, {
 			tabId: lastCurrentTab.id,
@@ -346,11 +346,13 @@ browser.windows.onFocusChanged.addListener(async (windowId) => {
 		// The window might not be valid. For example, if it's a devtools window.
 		if (!(await isValidWindow(windowId))) return;
 
-		await sendMessageSafe("currentTabChanged", undefined, {
-			tabId: lastCurrentTab.id,
-		});
+		if (lastCurrentTab) {
+			await sendMessageSafe("currentTabChanged", undefined, {
+				tabId: lastCurrentTab.id,
+			});
+		}
 
-		lastCurrentTab = await getCurrentTab();
+		lastCurrentTab = await getRequiredCurrentTab();
 		await sendMessageSafe("currentTabChanged", undefined, {
 			tabId: lastCurrentTab.id,
 		});

--- a/src/background/commands/commandListeners.ts
+++ b/src/background/commands/commandListeners.ts
@@ -27,7 +27,10 @@ import {
 } from "../tabs/focusTabBySound";
 import { cycleTabsByText, focusTabByText } from "../tabs/focusTabByText";
 import { getBareTitle } from "../tabs/getBareTitle";
-import { getCurrentTab, getCurrentTabId } from "../tabs/getCurrentTab";
+import {
+	getRequiredCurrentTab,
+	getRequiredCurrentTabId,
+} from "../tabs/getCurrentTab";
 import {
 	muteAllTabsWithSound,
 	muteNextTabWithSound,
@@ -100,7 +103,7 @@ export function addCommandListeners() {
 	});
 
 	onCommand("cloneCurrentTab", async () => {
-		await browser.tabs.duplicate(await getCurrentTabId());
+		await browser.tabs.duplicate(await getRequiredCurrentTabId());
 	});
 
 	onCommand("closeNextTabsInWindow", async ({ amount }) => {
@@ -147,7 +150,7 @@ export function addCommandListeners() {
 
 	onCommand("copyCurrentTabMarkdownUrl", async () => {
 		const bareTitle = await getBareTitle();
-		const tab = await getCurrentTab();
+		const tab = await getRequiredCurrentTab();
 		const markdownUrl = `[${bareTitle}](${tab.url!})`;
 
 		await notify.success("Markdown link copied to the clipboard.");
@@ -156,7 +159,7 @@ export function addCommandListeners() {
 	});
 
 	onCommand("copyLocationProperty", async ({ property }) => {
-		const tab = await getCurrentTab();
+		const tab = await getRequiredCurrentTab();
 		const url = new URL(tab.url!);
 
 		await notify.success(`Property "${property}" copied to the clipboard.`);
@@ -182,7 +185,7 @@ export function addCommandListeners() {
 	});
 
 	onCommand("moveCurrentTabToNewWindow", async () => {
-		const tabId = await getCurrentTabId();
+		const tabId = await getRequiredCurrentTabId();
 		await browser.windows.create({ tabId });
 	});
 

--- a/src/background/hints/labels/webNavigation.ts
+++ b/src/background/hints/labels/webNavigation.ts
@@ -3,7 +3,7 @@ import {
 	UnreachableContentScriptError,
 	sendMessage,
 } from "../../messaging/backgroundMessageBroker";
-import { getCurrentTabId } from "../../tabs/getCurrentTab";
+import { getRequiredCurrentTabId } from "../../tabs/getCurrentTab";
 import { getAllFrames } from "../../utils/getAllFrames";
 import { initStack } from "./labelStack";
 
@@ -107,12 +107,12 @@ export async function navigationOccurred(tabId: number) {
 // We use the onCommitted event to retrieve the URL since the main frame is
 // guarantied to come before the rest.
 async function preloadTabCommitted(url: string) {
-	const currentTabId = await getCurrentTabId();
+	const currentTabId = await getRequiredCurrentTabId();
 	preloadTabs.set(currentTabId, { url, completed: false });
 }
 
 async function preloadTabCompleted() {
-	const currentTabId = await getCurrentTabId();
+	const currentTabId = await getRequiredCurrentTabId();
 	const preloadTab = preloadTabs.get(currentTabId)!;
 	preloadTab.completed = true;
 }

--- a/src/background/hints/toggleHints.ts
+++ b/src/background/hints/toggleHints.ts
@@ -1,7 +1,7 @@
 import { retrieve, store } from "../../common/storage/storage";
 import { type ToggleLevel } from "../../typings/Action";
 import { sendMessage } from "../messaging/backgroundMessageBroker";
-import { getCurrentTab } from "../tabs/getCurrentTab";
+import { getRequiredCurrentTab } from "../tabs/getCurrentTab";
 
 export async function toggleHintsGlobal() {
 	const hintsToggleGlobal = await retrieve("hintsToggleGlobal");
@@ -11,77 +11,66 @@ export async function toggleHintsGlobal() {
 }
 
 export async function updateHintsToggle(level: ToggleLevel, enable?: boolean) {
-	const currentTab = await getCurrentTab();
+	if (level === "everywhere") {
+		if (enable === undefined) {
+			await store("hintsToggleGlobal", true);
+			await store("hintsToggleTabs", new Map());
+			await store("hintsToggleHosts", new Map());
+			await store("hintsTogglePaths", new Map());
+			await sendMessage("updateNavigationToggle", { enable });
+		}
+
+		return;
+	}
+
+	if (level === "now") {
+		await sendMessage("updateNavigationToggle", { enable });
+		return;
+	}
+
+	if (level === "global") {
+		await store("hintsToggleGlobal", enable ?? true);
+		return;
+	}
+
+	const currentTab = await getRequiredCurrentTab();
 	const { host, origin, pathname } = new URL(currentTab.url!);
 
-	switch (level) {
-		case "everywhere": {
-			if (enable === undefined) {
-				await store("hintsToggleGlobal", true);
-				await store("hintsToggleTabs", new Map());
-				await store("hintsToggleHosts", new Map());
-				await store("hintsTogglePaths", new Map());
-				await sendMessage("updateNavigationToggle", {
-					enable,
-				});
-			}
+	if (level === "tab") {
+		const hintsToggleTabs = await retrieve("hintsToggleTabs");
 
-			break;
+		if (enable === undefined) {
+			hintsToggleTabs.delete(currentTab.id!);
+		} else {
+			hintsToggleTabs.set(currentTab.id!, enable);
 		}
 
-		case "now": {
-			await sendMessage("updateNavigationToggle", {
-				enable,
-			});
-			break;
+		await store("hintsToggleTabs", hintsToggleTabs);
+		return;
+	}
+
+	if (level === "host") {
+		const hintsToggleHosts = await retrieve("hintsToggleHosts");
+
+		if (enable === undefined) {
+			hintsToggleHosts.delete(host);
+		} else {
+			hintsToggleHosts.set(host, enable);
 		}
 
-		case "global": {
-			await store("hintsToggleGlobal", enable ?? true);
-			break;
+		await store("hintsToggleHosts", hintsToggleHosts);
+		return;
+	}
+
+	if (level === "page") {
+		const hintsTogglePaths = await retrieve("hintsTogglePaths");
+
+		if (enable === undefined) {
+			hintsTogglePaths.delete(origin + pathname);
+		} else {
+			hintsTogglePaths.set(origin + pathname, enable);
 		}
 
-		case "tab": {
-			const hintsToggleTabs = await retrieve("hintsToggleTabs");
-			if (enable === undefined) {
-				hintsToggleTabs.delete(currentTab.id!);
-			} else {
-				hintsToggleTabs.set(currentTab.id!, enable);
-			}
-
-			await store("hintsToggleTabs", hintsToggleTabs);
-
-			break;
-		}
-
-		case "host": {
-			const hintsToggleHosts = await retrieve("hintsToggleHosts");
-			if (host) {
-				if (enable === undefined) {
-					hintsToggleHosts.delete(host);
-				} else {
-					hintsToggleHosts.set(host, enable);
-				}
-			}
-
-			await store("hintsToggleHosts", hintsToggleHosts);
-
-			break;
-		}
-
-		case "page": {
-			const hintsTogglePaths = await retrieve("hintsTogglePaths");
-			if (origin && pathname) {
-				if (enable === undefined) {
-					hintsTogglePaths.delete(origin + pathname);
-				} else {
-					hintsTogglePaths.set(origin + pathname, enable);
-				}
-			}
-
-			await store("hintsTogglePaths", hintsTogglePaths);
-
-			break;
-		}
+		await store("hintsTogglePaths", hintsTogglePaths);
 	}
 }

--- a/src/background/messaging/backgroundMessageBroker.ts
+++ b/src/background/messaging/backgroundMessageBroker.ts
@@ -24,7 +24,7 @@ import {
 	type Target,
 } from "../../typings/Target/Target";
 import { getRequiredStack } from "../hints/labels/labelStack";
-import { getCurrentTabId } from "../tabs/getCurrentTab";
+import { getRequiredCurrentTabId } from "../tabs/getCurrentTab";
 import { assertReferencesInCurrentTab } from "../target/references";
 import { getAllFrames } from "../utils/getAllFrames";
 import { promiseAllSettledGrouped } from "../utils/promises";
@@ -122,7 +122,7 @@ export async function sendMessage<K extends MessageWithoutTarget>(
 		: [data?: MessageData<K>, destination?: Destination]
 ): Promise<MessageReturn<K>> {
 	const [data, destination] = args;
-	const tabId = destination?.tabId ?? (await getCurrentTabId());
+	const tabId = destination?.tabId ?? (await getRequiredCurrentTabId());
 	await pingContentScript(tabId);
 
 	try {
@@ -173,7 +173,7 @@ export async function sendMessageToAllFrames<K extends MessageWithoutTarget>(
 		: [data?: MessageData<K>, tabId?: number]
 ) {
 	const [data, tabId] = args;
-	const tabId_ = tabId ?? (await getCurrentTabId());
+	const tabId_ = tabId ?? (await getRequiredCurrentTabId());
 
 	const frames = await getAllFrames(tabId_);
 
@@ -235,7 +235,7 @@ export async function sendMessageToTargetFrames<K extends MessageWithTarget>(
 	data: NonNullable<MessageData<K>>,
 	tabId?: number
 ) {
-	const destinationTabId = tabId ?? (await getCurrentTabId());
+	const destinationTabId = tabId ?? (await getRequiredCurrentTabId());
 	await pingContentScript(destinationTabId);
 
 	const targetByFrameMap = await splitTargetByFrame(

--- a/src/background/messaging/messageListeners.ts
+++ b/src/background/messaging/messageListeners.ts
@@ -8,7 +8,6 @@ import {
 } from "../hints/labels/labelAllocator";
 import { getRequiredStack, initStack } from "../hints/labels/labelStack";
 import { createRelatedTabs } from "../tabs/createRelatedTabs";
-import { getCurrentTabId } from "../tabs/getCurrentTab";
 import { getTabMarker } from "../tabs/tabMarkers";
 import {
 	onMessage,
@@ -59,14 +58,10 @@ export function addMessageListeners() {
 		return results.flat();
 	});
 
-	onMessage("getContentScriptContext", async (_, { tabId, frameId }) => {
-		const currentTabId = await getCurrentTabId();
-		return {
-			tabId,
-			frameId,
-			currentTabId,
-		};
-	});
+	onMessage("getContentScriptContext", async (_, { tabId, frameId }) => ({
+		tabId,
+		frameId,
+	}));
 
 	onMessage("clickHintInFrame", async ({ hint }, { tabId }) => {
 		await sendMessageToTargetFrames(

--- a/src/background/tabs/closeMatchingTabsInWindow.ts
+++ b/src/background/tabs/closeMatchingTabsInWindow.ts
@@ -1,5 +1,5 @@
 import browser, { type Tabs } from "webextension-polyfill";
-import { getCurrentTab } from "./getCurrentTab";
+import { getRequiredCurrentTab } from "./getCurrentTab";
 
 /**
  * Closes all tabs in the current window that match the filter function.
@@ -15,7 +15,7 @@ export async function closeFilteredTabsInWindow(
 		totalTabs: number
 	) => boolean
 ) {
-	const currentTab = await getCurrentTab();
+	const currentTab = await getRequiredCurrentTab();
 	const allTabsInWindow = await browser.tabs.query({ currentWindow: true });
 	const totalTabs = allTabsInWindow.length;
 

--- a/src/background/tabs/createRelatedTabs.ts
+++ b/src/background/tabs/createRelatedTabs.ts
@@ -1,6 +1,6 @@
 import browser, { type Tabs } from "webextension-polyfill";
 import { retrieve } from "../../common/storage/storage";
-import { getCurrentTabId } from "./getCurrentTab";
+import { getRequiredCurrentTabId } from "./getCurrentTab";
 
 /**
  * Create tabs related to the current tab. The index of the new tabs is
@@ -10,7 +10,7 @@ import { getCurrentTabId } from "./getCurrentTab";
 export async function createRelatedTabs(
 	createPropertiesArray: Tabs.CreateCreatePropertiesType[]
 ) {
-	const tabId = await getCurrentTabId();
+	const tabId = await getRequiredCurrentTabId();
 	let newIndex = await getNewTabIndex(tabId);
 
 	await Promise.all(

--- a/src/background/tabs/focusOrCreateTabByUrl.ts
+++ b/src/background/tabs/focusOrCreateTabByUrl.ts
@@ -1,5 +1,5 @@
 import browser from "webextension-polyfill";
-import { getCurrentTab } from "./getCurrentTab";
+import { getRequiredCurrentTab } from "./getCurrentTab";
 
 /**
  * Focuses or creates a tab with the given URL.
@@ -44,6 +44,6 @@ async function tabsQueryWithFallback(url: string) {
  * If none belongs to the current window, it returns the first one.
  */
 async function getTabPrioritizeCurrentWindow(tabs: browser.Tabs.Tab[]) {
-	const currentTab = await getCurrentTab();
+	const currentTab = await getRequiredCurrentTab();
 	return tabs.find((tab) => tab.windowId === currentTab.windowId) ?? tabs[0];
 }

--- a/src/background/tabs/focusTabByText.ts
+++ b/src/background/tabs/focusTabByText.ts
@@ -1,6 +1,6 @@
 import Fuse from "fuse.js";
 import browser from "webextension-polyfill";
-import { getCurrentTab } from "./getCurrentTab";
+import { getRequiredCurrentTab } from "./getCurrentTab";
 
 /**
  * All tabs matching the previous search.
@@ -54,7 +54,7 @@ export async function focusTabByText(text: string) {
  * Cycles through the tabs matching the previous tab search.
  */
 export async function cycleTabsByText(step: number) {
-	const currentTab = await getCurrentTab();
+	const currentTab = await getRequiredCurrentTab();
 
 	if (selectedMatch === undefined) {
 		throw new Error(`No previous tab search to cycle through.`);

--- a/src/background/tabs/getBareTitle.ts
+++ b/src/background/tabs/getBareTitle.ts
@@ -2,14 +2,14 @@ import {
 	sendMessage,
 	UnreachableContentScriptError,
 } from "../messaging/backgroundMessageBroker";
-import { getCurrentTab } from "./getCurrentTab";
+import { getRequiredCurrentTab } from "./getCurrentTab";
 
 export async function getBareTitle() {
 	try {
 		return await sendMessage("getTitleBeforeDecoration");
 	} catch (error: unknown) {
 		if (error instanceof UnreachableContentScriptError) {
-			const tab = await getCurrentTab();
+			const tab = await getRequiredCurrentTab();
 			return tab.title!;
 		}
 

--- a/src/background/tabs/getCurrentTab.ts
+++ b/src/background/tabs/getCurrentTab.ts
@@ -1,12 +1,12 @@
 import browser, { type Tabs } from "webextension-polyfill";
 
-export async function getCurrentTab(): Promise<Tabs.Tab> {
-	const currentTabArray = await browser.tabs.query({
-		currentWindow: true,
-		active: true,
-	});
-
-	const currentTab = currentTabArray[0];
+/**
+ * Returns the current tab.
+ *
+ * @throws {Error} If the current tab cannot be retrieved.
+ */
+export async function getRequiredCurrentTab(): Promise<Tabs.Tab> {
+	const currentTab = await getCurrentTab();
 
 	if (!currentTab) {
 		throw new Error("Unable to retrieve the current tab");
@@ -15,12 +15,29 @@ export async function getCurrentTab(): Promise<Tabs.Tab> {
 	return currentTab;
 }
 
-export async function getCurrentTabId(): Promise<number> {
+/**
+ * Returns the current tab id.
+ *
+ * @throws {Error} If the current tab id cannot be retrieved.
+ */
+export async function getRequiredCurrentTabId(): Promise<number> {
 	const currentTab = await getCurrentTab();
 
-	if (!currentTab.id) {
+	if (!currentTab?.id) {
 		throw new Error("Unable to retrieve the current tab id");
 	}
 
 	return currentTab.id;
+}
+
+/**
+ * Returns the current tab.
+ */
+export async function getCurrentTab() {
+	const currentTabArray = await browser.tabs.query({
+		currentWindow: true,
+		active: true,
+	});
+
+	return currentTabArray[0];
 }

--- a/src/background/tabs/getNextTabByIndex.ts
+++ b/src/background/tabs/getNextTabByIndex.ts
@@ -1,5 +1,5 @@
 import type browser from "webextension-polyfill";
-import { getCurrentTab } from "./getCurrentTab";
+import { getRequiredCurrentTab } from "./getCurrentTab";
 
 /**
  * Given an array of tabs as a parameter, return the first tab in the array that
@@ -8,7 +8,7 @@ import { getCurrentTab } from "./getCurrentTab";
  * the current window if necessary.
  */
 export async function getNextTabByIndex(tabs: browser.Tabs.Tab[]) {
-	const currentTab = await getCurrentTab();
+	const currentTab = await getRequiredCurrentTab();
 
 	return (
 		tabs.find(

--- a/src/background/tabs/muteTabs.ts
+++ b/src/background/tabs/muteTabs.ts
@@ -2,13 +2,13 @@ import browser from "webextension-polyfill";
 import { type TabMark, type Target } from "../../typings/Target/Target";
 import { getTabIdsFromTarget } from "../target/tabMarkers";
 import { notify } from "../utils/notify";
-import { getCurrentTabId } from "./getCurrentTab";
+import { getRequiredCurrentTabId } from "./getCurrentTab";
 import { getNextTabByIndex } from "./getNextTabByIndex";
 
 export async function muteTab(target?: Target<TabMark>, mute = true) {
 	const tabIds = target
 		? await getTabIdsFromTarget(target)
-		: [await getCurrentTabId()];
+		: [await getRequiredCurrentTabId()];
 
 	return Promise.all(
 		tabIds.map(async (tabId) => browser.tabs.update(tabId, { muted: mute }))

--- a/src/background/tabs/trackRecentTabs.ts
+++ b/src/background/tabs/trackRecentTabs.ts
@@ -1,7 +1,7 @@
 import { Mutex } from "async-mutex";
 import browser from "webextension-polyfill";
 import { retrieve, store } from "../../common/storage/storage";
-import { getCurrentTab } from "./getCurrentTab";
+import { getRequiredCurrentTab } from "./getCurrentTab";
 
 /**
  * Start tracking tabs to be able to use the command `focusPreviousTab`.
@@ -12,7 +12,7 @@ import { getCurrentTab } from "./getCurrentTab";
  */
 export async function trackRecentTabs() {
 	// We need to track the initial tab when the browser first opens
-	const currentTab = await getCurrentTab();
+	const currentTab = await getRequiredCurrentTab();
 	if (currentTab.windowId && currentTab.id) {
 		await updateRecentTab(currentTab.windowId, currentTab.id, false);
 	}

--- a/src/background/utils/getAllFrames.ts
+++ b/src/background/utils/getAllFrames.ts
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill";
 import { assertDefined } from "../../typings/TypingUtils";
-import { getCurrentTabId } from "../tabs/getCurrentTab";
+import { getRequiredCurrentTabId } from "../tabs/getCurrentTab";
 
 /**
  * Get all frames for the given tab id or the current tab if no tab id is
@@ -8,7 +8,7 @@ import { getCurrentTabId } from "../tabs/getCurrentTab";
  * happens for discarded tabs.
  */
 export async function getAllFrames(tabId?: number) {
-	const tabId_ = tabId ?? (await getCurrentTabId());
+	const tabId_ = tabId ?? (await getRequiredCurrentTabId());
 	const frames = await browser.webNavigation.getAllFrames({ tabId: tabId_ });
 	// For most us frames should be always defined. `getAllFrames` only returns
 	// null if the tab is discarded and we're usually sending messages to the

--- a/src/typings/ProtocolMap.ts
+++ b/src/typings/ProtocolMap.ts
@@ -23,7 +23,6 @@ export type BackgroundBoundMessageMap = {
 	getContentScriptContext: () => {
 		tabId: number;
 		frameId: number;
-		currentTabId: number;
 	};
 	getTabMarker: () => string;
 


### PR DESCRIPTION
- In some circumstances there's no need to have a current required tab id.
- Rename functions that get the current tab or tab id to make it more clear if they will throw if there is no current tab.
- Remove unnecessary `currentTabId` property when getting content script context