### PR TITLE
Improve tab markers

### DIFF
--- a/e2e/decorateTitle.test.ts
+++ b/e2e/decorateTitle.test.ts
@@ -1,5 +1,9 @@
 import { sleep } from "./utils/testHelpers";
 
+// There is another tab open before the current one that also gets a marker.
+// That's why we have to use this one.
+const tabMarker = "B";
+
 beforeAll(async () => {
 	await page.goto("http://localhost:8080/basic.html");
 });
@@ -9,7 +13,9 @@ test("The URL and the tab marker are attached to the title", async () => {
 
 	const title = await page.title();
 
-	expect(title).toBe("A | Document - http://localhost:8080/basic.html");
+	expect(title).toBe(
+		`${tabMarker} | Document - http://localhost:8080/basic.html`
+	);
 });
 
 test("If something in the page changes and the URL changes it updates the title", async () => {
@@ -22,7 +28,9 @@ test("If something in the page changes and the URL changes it updates the title"
 
 	const title = await page.title();
 
-	expect(title).toBe("A | Document - http://localhost:8080/new.html");
+	expect(title).toBe(
+		`${tabMarker} | Document - http://localhost:8080/new.html`
+	);
 });
 
 test("If the hash changes the URL in the title is updated", async () => {
@@ -36,5 +44,7 @@ test("If the hash changes the URL in the title is updated", async () => {
 
 	const title = await page.title();
 
-	expect(title).toBe("A | Document - http://localhost:8080/new.html#first");
+	expect(title).toBe(
+		`${tabMarker} | Document - http://localhost:8080/new.html#first`
+	);
 });

--- a/src/background/tabs/tabMarkers.ts
+++ b/src/background/tabs/tabMarkers.ts
@@ -7,114 +7,90 @@ import {
 } from "../messaging/backgroundMessageBroker";
 import { withLockedStorageAccess } from "../utils/withLockedStorageValue";
 
-export async function getTabMarker(tabId: number) {
-	return withLockedStorageAccess("tabMarkers", ({ free, assigned }) => {
-		const marker = assigned.get(tabId) ?? free.pop();
-		if (!marker) return "";
-		assigned.set(tabId, marker);
-		return marker;
-	});
+function isTabWithId(
+	tab: browser.Tabs.Tab
+): tab is browser.Tabs.Tab & { id: number } {
+	return tab.id !== undefined;
 }
 
-async function assignTabMarker(tabId: number, marker: string) {
-	return withLockedStorageAccess("tabMarkers", ({ free, assigned }) => {
-		if (!free.includes(marker)) {
-			throw new Error(
-				`Unable to assign marker ${marker} as it's already in use`
-			);
-		}
-
-		const markerIndex = free.indexOf(marker);
-		free.splice(markerIndex, 1);
-
-		assigned.set(tabId, marker);
-	});
+export async function getTabMarker(tabId: number) {
+	const { assigned } = await retrieve("tabMarkers");
+	const marker = assigned.get(tabId);
+	return marker;
 }
 
 export async function getTabIdForMarker(marker: string) {
-	return withLockedStorageAccess("tabMarkers", ({ assigned }) => {
-		for (const [tabId, currentMarker] of assigned.entries()) {
-			if (currentMarker === marker) {
-				return tabId;
-			}
+	const { assigned } = await retrieve("tabMarkers");
+	for (const [tabId, currentMarker] of assigned.entries()) {
+		if (currentMarker === marker) {
+			return tabId;
 		}
+	}
 
-		throw new Error(`No tab with the marker "${marker}"`);
-	});
+	throw new Error(`No tab with the marker "${marker}"`);
 }
 
-async function releaseMarker(tabId: number) {
-	const marker = await getTabMarker(tabId);
-	if (!marker) return;
-
-	await withLockedStorageAccess("tabMarkers", ({ free, assigned }) => {
-		assigned.delete(tabId);
-		free.push(marker);
-		free.sort((a, b) => b.length - a.length || b.localeCompare(a));
-	});
-}
-
-browser.tabs.onRemoved.addListener(async (tabId) => {
-	await releaseMarker(tabId);
-});
-
-// In Chrome when a tab is discarded it changes its id
-browser.tabs.onReplaced.addListener(async (addedTabId, removedTabId) => {
-	await withLockedStorageAccess("tabMarkers", ({ assigned }) => {
-		const tabMarker = assigned.get(removedTabId);
-		if (!tabMarker) return;
-
-		assigned.delete(removedTabId);
-		assigned.set(addedTabId, tabMarker);
-	});
-});
-
+/**
+ * Initializes the tab markers.
+ *
+ * It will assign tab markers to the tabs that already have one in their title
+ * in case the user has the setting "Continue where you left off" enabled.
+ */
 export async function initTabMarkers() {
 	await resetTabMarkers();
 
 	// We need to assign the tab markers to their corresponding tab id in case
-	// the user has the setting "Continue where you left off" enabled. If we don't
-	// those tabs will have an invalid tab marker.
-
-	if (!(await retrieve("includeTabMarkers"))) return;
+	// the user has the setting "Continue where you left off" enabled. If we
+	// don't those tabs will have an invalid tab marker.
 
 	const tabs = await browser.tabs.query({});
 
-	const getMarkerFromTitle = (title: string) => {
-		return /^([a-z]{1,2}) \| /i.exec(title)?.[1]?.toLowerCase();
-	};
+	const tabsAndTheirMarkers = tabs
+		.filter((tab) => isTabWithId(tab))
+		.map((tab) => ({ tab, marker: getMarkerFromTitle(tab.title!) }));
 
-	await Promise.allSettled(
-		tabs.map(async ({ title, id }) => {
-			if (!title || !id) return;
+	const tabsWithMarkers = tabsAndTheirMarkers.filter((tab) => tab.marker);
+	const tabsWithoutMarkers = tabsAndTheirMarkers.filter((tab) => !tab.marker);
 
-			const marker = getMarkerFromTitle(title);
-			if (!marker) return;
-
-			try {
-				await assignTabMarker(id, marker);
-			} catch {
-				// If the tab marker is already in use we reload the tab so it gets a
-				// new one. I'm not entirely sure if this is necessary but I leave it
-				// here just to be safe.
-				return browser.tabs.reload(id);
-			}
-		})
+	// In order to avoid having to reload tabs that already have a tab marker
+	// in their title we first try to assign tab markers to the tabs that
+	// already have one.
+	await Promise.all(
+		tabsWithMarkers.map(async ({ tab, marker }) => setTabMarker(tab.id, marker))
 	);
+
+	// Then the rest.
+	await Promise.all(
+		tabsWithoutMarkers.map(async ({ tab }) => setTabMarker(tab.id))
+	);
+
+	addTabCycleListeners();
 }
 
 export async function refreshTabMarkers() {
 	await resetTabMarkers();
 
 	const tabs = await browser.tabs.query({});
+	const tabWithIds = tabs.filter((tab) => isTabWithId(tab));
 
-	const refreshing = tabs.map(async (tab) => {
+	await withLockedStorageAccess("tabMarkers", ({ free, assigned }) => {
+		for (const tab of tabWithIds) {
+			const marker = free.pop();
+			if (marker) assigned.set(tab.id, marker);
+		}
+	});
+
+	const refreshing = tabWithIds.map(async (tab) => {
 		try {
 			await sendMessage("refreshTitleDecorations", undefined, {
 				tabId: tab.id,
 			});
 		} catch (error: unknown) {
-			if (!(error instanceof UnreachableContentScriptError)) throw error;
+			if (!(error instanceof UnreachableContentScriptError)) {
+				// We simply log the error. We don't throw because we don't want the
+				// whole command to fail if one tab fails
+				console.error(error);
+			}
 
 			// We reload if the tab has been discarded and the content script isn't
 			// running any more. I could check the `discarded` property of the tab but
@@ -128,10 +104,72 @@ export async function refreshTabMarkers() {
 	await Promise.all(refreshing);
 }
 
+/**
+ * Sets the tab marker for the given tab id.
+ *
+ * @param tabId - The tab id to set the marker for.
+ * @param preferredMarker - The preferred marker to use.
+ * @returns The marker that was set.
+ */
+async function setTabMarker(tabId: number, preferredMarker?: string) {
+	return withLockedStorageAccess("tabMarkers", ({ free, assigned }) => {
+		if (preferredMarker && free.includes(preferredMarker)) {
+			const markerIndex = free.indexOf(preferredMarker);
+			free.splice(markerIndex, 1);
+			assigned.set(tabId, preferredMarker);
+
+			return preferredMarker;
+		}
+
+		const newMarker = free.pop();
+		if (newMarker) assigned.set(tabId, newMarker);
+
+		return newMarker;
+	});
+}
+
+/**
+ * Releases the tab marker for the given tab id.
+ *
+ * @param tabId - The tab id to release the marker for.
+ * @returns The released marker or undefined if the tab doesn't have a marker.
+ */
+async function releaseTabMarker(tabId: number) {
+	return withLockedStorageAccess("tabMarkers", ({ free, assigned }) => {
+		const marker = assigned.get(tabId);
+		if (!marker) return;
+
+		assigned.delete(tabId);
+		free.push(marker);
+		free.sort((a, b) => b.length - a.length || b.localeCompare(a));
+
+		return marker;
+	});
+}
+
 async function resetTabMarkers() {
 	await withLockedStorageAccess("tabMarkers", (tabMarkers) => {
 		tabMarkers.free = [...letterLabels];
-		tabMarkers.assigned = new Map();
-		return tabMarkers;
+		tabMarkers.assigned.clear();
+	});
+}
+
+function getMarkerFromTitle(title: string) {
+	return /^([a-z]{1,2}) \| /i.exec(title)?.[1]?.toLowerCase();
+}
+
+function addTabCycleListeners() {
+	browser.tabs.onCreated.addListener(async ({ id }) => {
+		if (id) await setTabMarker(id);
+	});
+
+	browser.tabs.onRemoved.addListener(async (tabId) => {
+		await releaseTabMarker(tabId);
+	});
+
+	// In Chrome when a tab is discarded it changes its id
+	browser.tabs.onReplaced.addListener(async (addedTabId, removedTabId) => {
+		const marker = await releaseTabMarker(removedTabId);
+		await setTabMarker(addedTabId, marker);
 	});
 }

--- a/src/common/storage/defaultStorage.ts
+++ b/src/common/storage/defaultStorage.ts
@@ -8,7 +8,6 @@ export const defaultStorage: StorageSchema = {
 	labelStacks: new Map(),
 	tabMarkers: {
 		free: letterLabels,
-		tabIdsToMarkers: new Map(),
-		markersToTabIds: new Map(),
+		assigned: new Map(),
 	},
 } as const;

--- a/src/content/setup/decorateTitle.ts
+++ b/src/content/setup/decorateTitle.ts
@@ -85,6 +85,8 @@ async function getTitlePrefix() {
 	if (!(await shouldIncludeTabMarkers())) return "";
 
 	const tabMarker = await sendMessage("getTabMarker");
+	if (!tabMarker) return "";
+
 	const marker = getSetting("uppercaseTabMarkers")
 		? tabMarker.toUpperCase()
 		: tabMarker;

--- a/src/typings/ProtocolMap.ts
+++ b/src/typings/ProtocolMap.ts
@@ -24,7 +24,7 @@ export type BackgroundBoundMessageMap = {
 		tabId: number;
 		frameId: number;
 	};
-	getTabMarker: () => string;
+	getTabMarker: () => string | undefined;
 
 	// Hints Allocator
 	initStack: () => void;

--- a/src/typings/StorageSchema.ts
+++ b/src/typings/StorageSchema.ts
@@ -17,8 +17,7 @@ export type LabelStack = z.infer<typeof zLabelStack>;
 
 const zTabMarkers = z.object({
 	free: z.array(z.string()),
-	tabIdsToMarkers: z.map(z.number(), z.string()),
-	markersToTabIds: z.map(z.string(), z.number()),
+	assigned: z.map(z.number(), z.string()),
 });
 
 export type TabMarkers = z.infer<typeof zTabMarkers>;

--- a/src/typings/StorageSchema.ts
+++ b/src/typings/StorageSchema.ts
@@ -20,8 +20,6 @@ const zTabMarkers = z.object({
 	assigned: z.map(z.number(), z.string()),
 });
 
-export type TabMarkers = z.infer<typeof zTabMarkers>;
-
 export const zStorageSchema = z.object({
 	// Hint style
 	hintUppercaseLetters: z.boolean(),


### PR DESCRIPTION
This PR makes it so that all tab marker assignment happens in the background script. That makes it easier to reason about it and more robust. It also simplifies the tab marker object we moving the need to have two separate maps to store tab marker to id relations.