### PR TITLE
Remove unnecessary web accessible resources entries from manifest

### DIFF
--- a/src/manifests/chrome/manifest.json
+++ b/src/manifests/chrome/manifest.json
@@ -80,11 +80,5 @@
 			"48": "../../assets/icon48.png"
 		},
 		"default_title": "Rango"
-	},
-	"web_accessible_resources": [
-		{
-			"resources": ["../../content/actions/clipboardWriteInterceptor.js"],
-			"matches": ["<all_urls>"]
-		}
-	]
+	}
 }

--- a/src/manifests/firefox/manifest.json
+++ b/src/manifests/firefox/manifest.json
@@ -90,8 +90,5 @@
 	"browser_action": {
 		"default_icon": "../../assets/icon48.png",
 		"default_title": "Rango"
-	},
-	"web_accessible_resources": [
-		"../../content/actions/clipboardWriteInterceptor.js"
-	]
+	}
 }

--- a/src/manifests/safari/manifest.json
+++ b/src/manifests/safari/manifest.json
@@ -76,9 +76,5 @@
 	"browser_action": {
 		"default_icon": "../../assets/icon48.png",
 		"default_title": "Rango"
-	},
-	"web_accessible_resources": [
-		"../../content/actions/clipboardWriteInterceptor.js",
-		"clipboardWriteInterceptor.js"
-	]
+	}
 }


### PR DESCRIPTION
These are added automatically by Parcel to the generated manifest so there is no need to explicitly include them.