### PR TITLE
Increase contrast for code font on settings page

### DIFF
--- a/src/pages/settings/index.css
+++ b/src/pages/settings/index.css
@@ -50,4 +50,5 @@ code {
 	background-color: var(--slate-200);
 	padding: 0.1em 0.25em;
 	border-radius: 0.1em;
+	color: var(--slate-700);
 }


### PR DESCRIPTION
The only spot this is used is the text "Add Keys to Exclude". This change increases the contrast from 3.86:1 to 8.39:1
![code-contrast-after](https://github.com/user-attachments/assets/2837710e-70b1-440e-9ebc-5bcd724ffa1b)
![code-contrast-before](https://github.com/user-attachments/assets/81221289-1ba8-4af6-93f6-4c6694e4cefc)
