### PR TITLE
Fix error typing keys when hints are off

### DIFF
--- a/src/background/hints/labels/labelStack.ts
+++ b/src/background/hints/labels/labelStack.ts
@@ -5,10 +5,9 @@ import { store } from "../../../common/storage/store";
 import { type LabelStack } from "../../../typings/LabelStack";
 
 export async function initStack(tabId: number) {
-	return store.withLock(`labelStack:${tabId}`, async (stack) => {
-		stack = await createStack(tabId);
-		return [stack, stack];
-	});
+	const stack = await createStack(tabId);
+	await store.set(`labelStack:${tabId}`, stack);
+	return stack;
 }
 
 export async function getStack(tabId: number) {


### PR DESCRIPTION
Fixes the message `No value exists for key "labelStack:..." and not initializer was provided` appearing when using a direct clicking command (intending to type the characters) and hints are off.