### PR TITLE
Associate label with select element on options page

### DIFF
--- a/src/pages/settings/Select.tsx
+++ b/src/pages/settings/Select.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from "react";
+import { useId } from "react";
 import "./Select.css";
 
 type OptionProps = {
@@ -25,10 +26,13 @@ export function Select<T extends string>({
 	onChange,
 	children,
 }: SelectProps<T>) {
+	const id = useId();
+	
 	return (
 		<div className={`Select ${isDisabled ? "disabled" : ""}`}>
-			{label}
+			<label htmlFor={id}>{label}</label>
 			<select
+				id={id}
 				value={defaultValue}
 				disabled={isDisabled}
 				onChange={(event) => {

--- a/src/pages/settings/Select.tsx
+++ b/src/pages/settings/Select.tsx
@@ -1,5 +1,5 @@
-import { type ReactNode } from "react";
 import { useId } from "react";
+import { type ReactNode } from "react";
 import "./Select.css";
 
 type OptionProps = {
@@ -27,7 +27,7 @@ export function Select<T extends string>({
 	children,
 }: SelectProps<T>) {
 	const id = useId();
-	
+
 	return (
 		<div className={`Select ${isDisabled ? "disabled" : ""}`}>
 			<label htmlFor={id}>{label}</label>

--- a/src/pages/settings/Select.tsx
+++ b/src/pages/settings/Select.tsx
@@ -1,5 +1,4 @@
-import { useId } from "react";
-import { type ReactNode } from "react";
+import { type ReactNode, useId } from "react";
 import "./Select.css";
 
 type OptionProps = {


### PR DESCRIPTION
On the options page, the select element dropdown for "Position" has a visible label but it's not associated with the select element it's visually connected to. This change wraps the existing visible label in a <label> element and assigns it as the label for the select element.

I'm not too familiar with React, so I used the same {id} configuration found in TextInput.tsx and it appears to work correctly without any unintended consequences.

Alternatively, you could assign aria-label={label} inside of the select tag like this:

```
<select
	aria-label={label}
	value={defaultValue}
	disabled={isDisabled}
	onChange={(event) => {
		onChange(event.target.value as T);
	}}
>
	{children}
</select>
```

They both accomplish the same thing but in a slightly different way.