### PR TITLE
Increase contrast for disabled toggles and label radio button groups

### DIFF
--- a/src/pages/settings/RadioGroup.tsx
+++ b/src/pages/settings/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useContext, useMemo } from "react";
+import { createContext, type ReactNode, useContext, useMemo, useId } from "react";
 import "./RadioGroup.css";
 
 type TypeRadioContext = {
@@ -64,11 +64,14 @@ export function RadioGroup<T extends string>({
 		() => ({ name, selectedValue: defaultValue, isDisabled, onChange }),
 		[name, defaultValue, isDisabled, onChange]
 	);
+	const id = useId();
 
 	return (
 		<RadioContext.Provider value={contextValue}>
-			<div className={`RadioGroup ${isDisabled ? "disabled" : ""}`}>
-				{label}
+			<div className={`RadioGroup ${isDisabled ? "disabled" : ""}`}
+				role="radiogroup"
+				aria-labelledby={id}>
+				<label id={id}>{label}</label>
 				<div className="options">{children}</div>
 			</div>
 		</RadioContext.Provider>

--- a/src/pages/settings/RadioGroup.tsx
+++ b/src/pages/settings/RadioGroup.tsx
@@ -1,4 +1,10 @@
-import { createContext, type ReactNode, useContext, useMemo, useId } from "react";
+import {
+	createContext,
+	type ReactNode,
+	useContext,
+	useMemo,
+	useId,
+} from "react";
 import "./RadioGroup.css";
 
 type TypeRadioContext = {
@@ -68,9 +74,11 @@ export function RadioGroup<T extends string>({
 
 	return (
 		<RadioContext.Provider value={contextValue}>
-			<div className={`RadioGroup ${isDisabled ? "disabled" : ""}`}
+			<div
+				className={`RadioGroup ${isDisabled ? "disabled" : ""}`}
 				role="radiogroup"
-				aria-labelledby={id}>
+				aria-labelledby={id}
+			>
 				<label id={id}>{label}</label>
 				<div className="options">{children}</div>
 			</div>

--- a/src/pages/settings/Toggle.css
+++ b/src/pages/settings/Toggle.css
@@ -4,7 +4,7 @@
 }
 
 .Toggle.disabled label {
-	color: var(--neutral-500);
+	color: var(--neutral-600);
 }
 
 .Toggle button {

--- a/src/pages/settings/index.css
+++ b/src/pages/settings/index.css
@@ -22,6 +22,7 @@
 	--orange-700: #c2410c;
 	--blue-600: #2563eb;
 	--neutral-500: #a3a3a3;
+	--neutral-600: #757575;
 }
 
 html {


### PR DESCRIPTION
This change focuses on a few minor tweaks with minimal visual impact. The text for disabled toggles is a bit less than the 4.5:1 that's required by WCAG AA so this change adds a slightly darker text color to it while still keeping it visually distinct when it's in a disabled state. The second part wraps the radio button section label in a label tag and assigns it as the aria-labelledby value for the radiogroup. Using fieldset and legend tags would have provided a similar grouping option, but since it's React and the radio buttons and groupings are custom this method has the same effect. 