### PR TITLE
Add text-aware element labeling feature

### DIFF
--- a/src/common/settings/settingsSchema.ts
+++ b/src/common/settings/settingsSchema.ts
@@ -121,6 +121,9 @@ export const settingsSchema = z.object({
 	// Always compute hintables
 	alwaysComputeHintables: z.boolean().default(false),
 
+	// Text-aware hinting
+	onlyHintElementsWithoutText: z.boolean().default(false),
+
 	// Notifications
 	enableNotifications: z.boolean().default(true),
 	notifyWhenTogglingHints: z.boolean().default(false),

--- a/src/content/dom/hasVisibleText.test.ts
+++ b/src/content/dom/hasVisibleText.test.ts
@@ -1,0 +1,691 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { hasVisibleText } from "./hasVisibleText";
+
+describe("hasVisibleText", () => {
+	beforeEach(() => {
+		document.body.innerHTML = "";
+	});
+
+	describe("Icon and Image Detection", () => {
+		test("should return false for img elements (should be hinted)", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<img src="test.jpg" alt="Test Image">'
+			);
+			const img = document.body.lastElementChild!;
+
+			expect(hasVisibleText(img)).toBe(false);
+		});
+
+		test("should return false for svg elements (should be hinted)", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<svg><circle cx="50" cy="50" r="40" /></svg>'
+			);
+			const svg = document.body.lastElementChild!;
+
+			expect(hasVisibleText(svg)).toBe(false);
+		});
+
+		test("should return false for canvas elements (should be hinted)", () => {
+			document.body.insertAdjacentHTML("beforeend", "<canvas></canvas>");
+			const canvas = document.body.lastElementChild!;
+
+			expect(hasVisibleText(canvas)).toBe(false);
+		});
+
+		test("should return false for video elements (should be hinted)", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<video src="test.mp4"></video>'
+			);
+			const video = document.body.lastElementChild!;
+
+			expect(hasVisibleText(video)).toBe(false);
+		});
+
+		test("should return false for audio elements (should be hinted)", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<audio src="test.mp3"></audio>'
+			);
+			const audio = document.body.lastElementChild!;
+
+			expect(hasVisibleText(audio)).toBe(false);
+		});
+
+		test("should return false for elements with role='img' (should be hinted)", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<div role="img">Icon</div>'
+			);
+			const div = document.body.lastElementChild!;
+
+			expect(hasVisibleText(div)).toBe(false);
+		});
+
+		test("should return false for Font Awesome icons", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<i class="fa-solid fa-home"></i>'
+			);
+			const icon = document.body.lastElementChild!;
+
+			expect(hasVisibleText(icon)).toBe(false);
+		});
+
+		test("should return false for generic icon elements", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<i class="icon-search"></i>'
+			);
+			const icon = document.body.lastElementChild!;
+
+			expect(hasVisibleText(icon)).toBe(false);
+		});
+
+		test("should return false for Material Icons", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<i class="material-icons">search</i>'
+			);
+			const icon = document.body.lastElementChild!;
+
+			expect(hasVisibleText(icon)).toBe(false);
+		});
+
+		test("should return false for buttons containing only Material Icons", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<button><i class="material-icons">add</i></button>'
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(false);
+		});
+
+		test("should return false for buttons with nested Material Icons (Workona-style)", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<button><div><div><i class="material-icons">more_vert</i></div></div></button>'
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(false);
+		});
+
+		test("should return true for buttons with Material Icons plus text", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<button><i class="material-icons">add</i> Add Item</button>'
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(true);
+		});
+
+		test("should return false for elements containing only Font Awesome icons", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<button><i class="fa-solid fa-home"></i></button>'
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(false);
+		});
+
+		test("should return false for elements containing only generic icons", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<span><i class="icon-search"></i></span>'
+			);
+			const span = document.body.lastElementChild!;
+
+			expect(hasVisibleText(span)).toBe(false);
+		});
+
+		test("should return false for buttons with Google Symbols (Meet-style)", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<button><span><i class="google-symbols">mic</i></span></button>'
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(false);
+		});
+
+		test("should return false for buttons with Google Symbols and complex nesting", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<button class="complex-button"><span><span><i class="quRWN-Bz112c google-symbols notranslate VfPpkd-kBDsod VcKVTb" aria-hidden="true">mic</i></span></span></button>'
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(false);
+		});
+
+		test("should return true for buttons with Google Symbols plus text", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<button><i class="google-symbols">mic</i> Microphone</button>'
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(true);
+		});
+	});
+
+	describe("Regular Elements with Text", () => {
+		test("should return true for elements with meaningful text", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				"<button>Click Me</button>"
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(true);
+		});
+
+		test("should return false for elements with only whitespace", () => {
+			document.body.insertAdjacentHTML("beforeend", "<div>   \n  \t  </div>");
+			const div = document.body.lastElementChild!;
+
+			expect(hasVisibleText(div)).toBe(false);
+		});
+
+		test("should return false for elements with single letter", () => {
+			document.body.insertAdjacentHTML("beforeend", "<button>x</button>");
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(false);
+		});
+
+		test("should return true for elements with single digit", () => {
+			document.body.insertAdjacentHTML("beforeend", "<button>5</button>");
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(true);
+		});
+
+		test("should return false for elements with only symbols", () => {
+			document.body.insertAdjacentHTML("beforeend", "<button>×</button>");
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(false);
+		});
+
+		test("should return true for elements with multi-character text", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				"<span>Save Document</span>"
+			);
+			const span = document.body.lastElementChild!;
+
+			expect(hasVisibleText(span)).toBe(true);
+		});
+
+		test("should return false for empty elements", () => {
+			document.body.insertAdjacentHTML("beforeend", "<div></div>");
+			const div = document.body.lastElementChild!;
+
+			expect(hasVisibleText(div)).toBe(false);
+		});
+	});
+
+	describe("Input Elements", () => {
+		test("should return true for input with value", () => {
+			document.body.insertAdjacentHTML("beforeend", '<input type="text">');
+			const input = document.body.lastElementChild! as HTMLInputElement;
+			input.value = "User input text";
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+
+		test("should return true for input with placeholder", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<input type="text" placeholder="Enter your name">'
+			);
+			const input = document.body.lastElementChild!;
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+
+		test("should return false for input with single letter value", () => {
+			document.body.insertAdjacentHTML("beforeend", '<input type="text">');
+			const input = document.body.lastElementChild! as HTMLInputElement;
+			input.value = "x";
+
+			expect(hasVisibleText(input)).toBe(false);
+		});
+
+		test("should return true for input with single digit value", () => {
+			document.body.insertAdjacentHTML("beforeend", '<input type="text">');
+			const input = document.body.lastElementChild! as HTMLInputElement;
+			input.value = "7";
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+
+		test("should return false for input with empty value and no placeholder", () => {
+			document.body.insertAdjacentHTML("beforeend", '<input type="text">');
+			const input = document.body.lastElementChild!;
+
+			expect(hasVisibleText(input)).toBe(false);
+		});
+
+		test("should return true for textarea with value", () => {
+			document.body.insertAdjacentHTML("beforeend", "<textarea></textarea>");
+			const textarea = document.body.lastElementChild! as HTMLTextAreaElement;
+			textarea.value = "Long text content";
+
+			expect(hasVisibleText(textarea)).toBe(true);
+		});
+
+		test("should return true for textarea with placeholder", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<textarea placeholder="Write your message here"></textarea>'
+			);
+			const textarea = document.body.lastElementChild!;
+
+			expect(hasVisibleText(textarea)).toBe(true);
+		});
+
+		test("should prioritize input value over placeholder", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<input type="text" placeholder="x">'
+			);
+			const input = document.body.lastElementChild! as HTMLInputElement;
+			input.value = "ab";
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+	});
+
+	describe("Select Elements", () => {
+		test("should return true for select with meaningful options", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<select>
+					<option value="1">Option One</option>
+					<option value="2">Option Two</option>
+				</select>
+			`
+			);
+			const select = document.body.lastElementChild!;
+
+			expect(hasVisibleText(select)).toBe(true);
+		});
+
+		test("should return false for select with only single letter options", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<select>
+					<option value="a">A</option>
+					<option value="b">B</option>
+				</select>
+			`
+			);
+			const select = document.body.lastElementChild!;
+
+			expect(hasVisibleText(select)).toBe(false);
+		});
+
+		test("should return true for select with single digit options", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<select>
+					<option value="1">1</option>
+					<option value="2">2</option>
+				</select>
+			`
+			);
+			const select = document.body.lastElementChild!;
+
+			expect(hasVisibleText(select)).toBe(true);
+		});
+
+		test("should return false for select with empty options", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<select>
+					<option value="1"></option>
+					<option value="2">  </option>
+				</select>
+			`
+			);
+			const select = document.body.lastElementChild!;
+
+			expect(hasVisibleText(select)).toBe(false);
+		});
+
+		test("should return true for select with mix of letters and meaningful options", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<select>
+					<option value="a">A</option>
+					<option value="full">Full Option Name</option>
+				</select>
+			`
+			);
+			const select = document.body.lastElementChild!;
+
+			expect(hasVisibleText(select)).toBe(true);
+		});
+
+		test("should return true for select with mix of digits and letters", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<select>
+					<option value="1">1</option>
+					<option value="a">A</option>
+				</select>
+			`
+			);
+			const select = document.body.lastElementChild!;
+
+			expect(hasVisibleText(select)).toBe(true);
+		});
+
+		test("should return false for empty select", () => {
+			document.body.insertAdjacentHTML("beforeend", "<select></select>");
+			const select = document.body.lastElementChild!;
+
+			expect(hasVisibleText(select)).toBe(false);
+		});
+	});
+
+	describe("Form Labels", () => {
+		test("should return true for input with associated label (for attribute)", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label for="test-input">Username</label>
+				<input type="text" id="test-input">
+			`
+			);
+			const input = document.body.querySelector("input")!;
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+
+		test("should return true for input wrapped in label", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label>
+					Email Address
+					<input type="email">
+				</label>
+			`
+			);
+			const input = document.body.querySelector("input")!;
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+
+		test("should return false for input with single letter label", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label for="test-input">A</label>
+				<input type="text" id="test-input">
+			`
+			);
+			const input = document.body.querySelector("input")!;
+
+			expect(hasVisibleText(input)).toBe(false);
+		});
+
+		test("should return true for input with single digit label", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label for="test-input">3</label>
+				<input type="text" id="test-input">
+			`
+			);
+			const input = document.body.querySelector("input")!;
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+
+		test("should return true for textarea with associated label", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label for="comment">Your Comment</label>
+				<textarea id="comment"></textarea>
+			`
+			);
+			const textarea = document.body.querySelector("textarea")!;
+
+			expect(hasVisibleText(textarea)).toBe(true);
+		});
+
+		test("should return true for select with associated label", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label for="country">Select Country</label>
+				<select id="country"></select>
+			`
+			);
+			const select = document.body.querySelector("select")!;
+
+			expect(hasVisibleText(select)).toBe(true);
+		});
+
+		test("should prioritize input value over label text", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label for="test-input">x</label>
+				<input type="text" id="test-input">
+			`
+			);
+			const input = document.body.querySelector("input")!;
+			// Label alone would return false (single letter), but value takes priority
+			input.value = "User entered text";
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+
+		test("should handle input without id but with wrapping label", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label>
+					Password
+					<input type="password">
+				</label>
+			`
+			);
+			const input = document.body.querySelector("input")!;
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+	});
+
+	describe("Edge Cases", () => {
+		test("should handle null textContent gracefully", () => {
+			document.body.insertAdjacentHTML("beforeend", "<div></div>");
+			const div = document.body.lastElementChild!;
+			Object.defineProperty(div, "textContent", {
+				value: null,
+				writable: true,
+			});
+
+			expect(hasVisibleText(div)).toBe(false);
+		});
+
+		test("should handle elements with multiple digits", () => {
+			document.body.insertAdjacentHTML("beforeend", "<span>42</span>");
+			const span = document.body.lastElementChild!;
+
+			expect(hasVisibleText(span)).toBe(true);
+		});
+
+		test("should handle elements with mixed text and numbers", () => {
+			document.body.insertAdjacentHTML("beforeend", "<div>Page 1 of 10</div>");
+			const div = document.body.lastElementChild!;
+
+			expect(hasVisibleText(div)).toBe(true);
+		});
+
+		test("should handle elements with special characters mixed with text", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				"<button>Save & Exit</button>"
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(true);
+		});
+
+		test("should return false for elements with only punctuation", () => {
+			document.body.insertAdjacentHTML("beforeend", "<span>...</span>");
+			const span = document.body.lastElementChild!;
+
+			expect(hasVisibleText(span)).toBe(false);
+		});
+
+		test("should handle complex icon class combinations", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<i class="fas fa-solid fa-home icon-large"></i>'
+			);
+			const icon = document.body.lastElementChild!;
+
+			expect(hasVisibleText(icon)).toBe(false);
+		});
+
+		test("should handle icons with nested content", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				'<i class="icon-search"><span>nested content</span></i>'
+			);
+			const icon = document.body.lastElementChild!;
+
+			expect(hasVisibleText(icon)).toBe(false);
+		});
+	});
+
+	describe("Complex Scenarios", () => {
+		test("should handle label with nested elements", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label for="test-input">Required <span class="required">*</span> Email</label>
+				<input type="email" id="test-input">
+			`
+			);
+			const input = document.body.querySelector("input")!;
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+
+		test("should return true when input has multiple labels and one is meaningful", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label for="multi-label">Meaningful Label</label>
+				<label for="multi-label">x</label>
+				<input type="text" id="multi-label">
+			`
+			);
+			const input = document.body.querySelector("input")!;
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+
+		test("should handle input with both associated and wrapping label", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<label for="dual-label">Associated Label</label>
+				<label>
+					Wrapping Label
+					<input type="text" id="dual-label">
+				</label>
+			`
+			);
+			const input = document.body.querySelector("input")!;
+
+			expect(hasVisibleText(input)).toBe(true);
+		});
+	});
+
+	describe("Hidden Elements", () => {
+		test("should return false for button with only hidden badge text (Google Docs style)", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<div role="button">
+					<div class="icon-container">&nbsp;</div>
+					<span style="display: none;">0</span>
+				</div>
+			`
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(false);
+		});
+
+		test("should return false for element with all text in hidden children", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<div>
+					<span style="display: none;">Hidden text</span>
+					<span style="visibility: hidden;">Also hidden</span>
+				</div>
+			`
+			);
+			const div = document.body.lastElementChild!;
+
+			expect(hasVisibleText(div)).toBe(false);
+		});
+
+		test("should return true for element with visible text and hidden badge", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<button>
+					Click me
+					<span style="display: none;">99</span>
+				</button>
+			`
+			);
+			const button = document.body.lastElementChild!;
+
+			expect(hasVisibleText(button)).toBe(true);
+		});
+
+		test("should return true when only some children are hidden", () => {
+			document.body.insertAdjacentHTML(
+				"beforeend",
+				`
+				<div>
+					<span style="display: none;">Hidden</span>
+					<span>Visible text here</span>
+				</div>
+			`
+			);
+			const div = document.body.lastElementChild!;
+
+			expect(hasVisibleText(div)).toBe(true);
+		});
+	});
+});

--- a/src/content/dom/hasVisibleText.ts
+++ b/src/content/dom/hasVisibleText.ts
@@ -1,0 +1,192 @@
+/**
+ * Utility functions for detecting visible text content in elements.
+ * Used to determine if elements should be hinted based on their text content.
+ */
+
+/**
+ * CSS selector for detecting icons, images, and visual-only elements.
+ * Used both for direct element detection and for filtering out icon text content.
+ */
+const iconAndVisualElementsSelector =
+	// Standard image and media elements
+	"img, svg, canvas, video, audio, " +
+	// Elements with semantic image role
+	"[role='img'], " +
+	// Icon font patterns - <i> tags with icon-related classes
+	"i[class*='icon'], " + // Generic icon libraries (Material Icons, Bootstrap Icons, etc.)
+	"i[class*='fa-'], " + // Font Awesome icons (fa-solid, fa-regular, fa-home, etc.)
+	"i[class*='material-icons'], " + // Material Design Icons specifically
+	"i[class*='google-symbols']"; // Google Symbols (used in Google Meet, etc.)
+
+/**
+ * Checks if an element is an icon, image, or visual-only element
+ * that should always be hintable regardless of text content.
+ */
+function isIconOrImage(element: Element): boolean {
+	return element.matches(iconAndVisualElementsSelector);
+}
+
+/**
+ * Checks if an element is hidden via CSS (display: none or visibility: hidden).
+ */
+function isElementHidden(element: Element): boolean {
+	const style = getComputedStyle(element);
+	return style.display === "none" || style.visibility === "hidden";
+}
+
+/**
+ * Gets text content from an element excluding text that comes from icon descendants
+ * and hidden elements. This helps identify when an element's text is purely from
+ * icon fonts or hidden badges vs meaningful visible content.
+ */
+function getTextExcludingIconDescendants(element: Element): string {
+	const texts: string[] = [];
+
+	function collectVisibleText(node: Node) {
+		if (node.nodeType === Node.TEXT_NODE) {
+			texts.push(node.textContent ?? "");
+			return;
+		}
+
+		if (node.nodeType === Node.ELEMENT_NODE) {
+			const el = node as Element;
+
+			// Skip icon elements
+			if (el.matches(iconAndVisualElementsSelector)) {
+				return;
+			}
+
+			// Skip hidden elements
+			if (isElementHidden(el)) {
+				return;
+			}
+
+			// Recurse into children
+			for (const child of node.childNodes) {
+				collectVisibleText(child);
+			}
+		}
+	}
+
+	// Iterate through children to collect visible text, skipping hidden descendants
+	for (const child of element.childNodes) {
+		collectVisibleText(child);
+	}
+
+	return texts.join("").trim();
+}
+
+/**
+ * Gets the text content from associated labels for form controls.
+ * This helper function extracts label text that can be used for voice targeting.
+ */
+function getAssociatedLabelText(element: Element): string | undefined {
+	if (!element.matches("input, select, textarea")) return undefined;
+
+	// Check for associated label element
+	const id = element.getAttribute("id");
+	const associatedLabel = id
+		? document.querySelector(`label[for="${id}"]`)
+		: null;
+	const wrappingLabel = element.closest("label");
+
+	// Return the first available label text
+	return (
+		associatedLabel?.textContent?.trim() ?? wrappingLabel?.textContent?.trim()
+	);
+}
+
+/**
+ * Checks if an element has meaningful visible text content.
+ * This looks for substantial text that would serve as a clear label,
+ * including text from the element itself and associated labels.
+ */
+function hasActualVisibleText(element: Element): boolean {
+	// Get visible text from element - for inputs, check value/placeholder
+	let elementText: string | undefined;
+
+	if (element.matches("input, textarea")) {
+		const inputElement = element as HTMLInputElement | HTMLTextAreaElement;
+		// For input elements, check value first, then placeholder, then text content
+		const value = inputElement.value?.trim();
+		const placeholder = inputElement.placeholder?.trim();
+		const textContent = getTextExcludingIconDescendants(element);
+
+		elementText =
+			value && value.length > 0
+				? value
+				: placeholder && placeholder.length > 0
+					? placeholder
+					: textContent;
+	} else if (element.matches("select")) {
+		// For select elements, check if there are meaningful options
+		const selectElement = element as HTMLSelectElement;
+		const options = Array.from(selectElement.options);
+		const meaningfulOptions = options.filter((option) => {
+			const text = option.textContent?.trim();
+			if (!text) return false;
+			// Allow multi-character text or single digits
+			return text.length > 1 || /\d/.test(text);
+		});
+		// If there are meaningful options, the select has targetable content
+		if (meaningfulOptions.length > 0) {
+			return true;
+		}
+
+		// For selects without meaningful options, don't use textContent
+		// because it concatenates all option text which may create false positives
+		elementText = undefined;
+	} else {
+		// For other elements, use text content excluding icon descendants
+		elementText = getTextExcludingIconDescendants(element);
+	}
+
+	// Check for associated label text for form controls
+	const labelText = getAssociatedLabelText(element);
+
+	// Combine all available text sources - prefer element text, fall back to label text
+	const allText =
+		elementText && elementText.length > 0 ? elementText : labelText;
+
+	// If no text at all, definitely no visible text
+	if (!allText || !/\w+/.test(allText)) {
+		return false;
+	}
+
+	// Allow single characters only if they are digits
+	if (allText.length === 1 && !/\d/.test(allText)) {
+		return false;
+	}
+
+	// If element has meaningful text content, it has visible text
+	return true;
+}
+
+/**
+ * Determines if an element contains visible text content that can be targeted by voice.
+ *
+ * The principle: If an element has visible text that can be targeted using voice text selection,
+ * then it doesn't need a Rango hint. Only elements without targetable text need hints.
+ *
+ * Elements are considered to have "no targetable text" (and thus should be hinted) if they are:
+ * - Icons, images, or visual-only elements
+ * - Interactive elements with only single characters or symbols
+ * - Form controls without any visible text (no value, placeholder, or label)
+ *
+ * Elements are considered to have "targetable text" (and thus should NOT be hinted) if they:
+ * - Contain multi-character visible text that can be spoken to target the element
+ * - Have associated labels that provide targetable text
+ * - Are form controls with meaningful values, placeholders, or option text
+ *
+ * @param element The element to check
+ * @returns false if element should be hinted (no targetable text), true if it has targetable text
+ */
+export function hasVisibleText(element: Element): boolean {
+	// Always hint icons and images - these are purely visual elements
+	if (isIconOrImage(element)) {
+		return false; // No targetable text, so should be hinted
+	}
+
+	// For all elements (including form controls), check if they have meaningful visible text
+	return hasActualVisibleText(element);
+}

--- a/src/content/dom/isVisible.ts
+++ b/src/content/dom/isVisible.ts
@@ -1,14 +1,15 @@
-import { getBoundingClientRect } from "../hints/layoutCache";
+import { getBoundingClientRect, getCachedStyle } from "../hints/layoutCache";
 
 export function isVisible(element: Element): boolean {
-	const { visibility, opacity } = getComputedStyle(element);
+	const { visibility, opacity } = getCachedStyle(element);
 	const { width, height } = getBoundingClientRect(element);
 
 	if (visibility === "hidden" || width < 5 || height < 5 || opacity === "0") {
 		// This handles custom checkboxes or radio buttons where the input element
-		// is hidden and replaced with an stylized sibling.
+		// is hidden and replaced with a stylized sibling.
 		if (
-			element.matches("input:is([type='checkbox'], [type='radio'])") &&
+			element instanceof HTMLInputElement &&
+			(element.type === "checkbox" || element.type === "radio") &&
 			element.parentElement &&
 			isVisible(element.parentElement)
 		) {
@@ -29,7 +30,7 @@ export function isVisible(element: Element): boolean {
 	let counter = 0;
 
 	while (current && counter < 4) {
-		const { opacity } = getComputedStyle(current);
+		const { opacity } = getCachedStyle(current);
 		if (opacity === "0") {
 			return false;
 		}

--- a/src/pages/settings/SettingsComponent.tsx
+++ b/src/pages/settings/SettingsComponent.tsx
@@ -107,6 +107,25 @@ export function SettingsComponent() {
 				</SettingRow>
 				<SettingRow>
 					<Toggle
+						label="Only hint elements without visible text"
+						isPressed={dirtySettings.onlyHintElementsWithoutText}
+						onClick={() => {
+							handleChange(
+								"onlyHintElementsWithoutText",
+								!dirtySettings.onlyHintElementsWithoutText
+							);
+						}}
+					>
+						<p className="explanation">
+							Only show hints for elements that don&apos;t have visible text
+							labels, such as icons, images, and unlabeled controls. Elements
+							with clear text like &quot;Submit&quot; buttons or
+							&quot;Home&quot; links will not be hinted.
+						</p>
+					</Toggle>
+				</SettingRow>
+				<SettingRow>
+					<Toggle
 						label="Show What's New page after updating"
 						isPressed={dirtySettings.showWhatsNewPageOnUpdate}
 						onClick={() => {

--- a/src/pages/settings/SettingsComponent.tsx
+++ b/src/pages/settings/SettingsComponent.tsx
@@ -117,10 +117,12 @@ export function SettingsComponent() {
 						}}
 					>
 						<p className="explanation">
-							Only show hints for elements that don&apos;t have visible text
-							labels, such as icons, images, and unlabeled controls. Elements
-							with clear text like &quot;Submit&quot; buttons or
-							&quot;Home&quot; links will not be hinted.
+							Reduces hint clutter by only hinting elements without visible text
+							(icons, images, unlabeled controls). Use with{" "}
+							<ExternalLink href="https://github.com/wolfmanstout/talon-gaze-ocr">
+								talon-gaze-ocr
+							</ExternalLink>{" "}
+							to target text elements by their visible text instead.
 						</p>
 					</Toggle>
 				</SettingRow>


### PR DESCRIPTION
Add option to only show hints for elements without visible text labels. When enabled, elements with clear text like 'Submit' buttons or 'Home' links will not be hinted, reducing visual clutter.

Features:
- New hasVisibleText module for detecting visible text content
- Detects icon fonts (Font Awesome, Material Icons, Google Symbols)
- Handles form controls with labels, values, and placeholders
- Filters out hidden elements (badges, screen-reader-only text)
- Settings toggle: 'Only hint elements without visible text'

Includes comprehensive test suite with 61 tests.