### PR TITLE
Prevent clipboard interceptor re-injection

### DIFF
--- a/src/content/actions/clipboardWriteInterceptor.js
+++ b/src/content/actions/clipboardWriteInterceptor.js
@@ -1,69 +1,80 @@
-const originalDocumentExecCommand = document.execCommand;
-const originalClipboardWrite = window.navigator.clipboard.write;
-const originalClipboardWriteText = window.navigator.clipboard.writeText;
-
-window.addEventListener("message", (event) => {
-	if (event.origin !== window.location.origin) return;
-
-	if (event.data.type === "RANGO_START_CLIPBOARD_WRITE_INTERCEPTION") {
-		startClipboardWriteInterception();
+(function () {
+	// Prevent re-injection: if already loaded, just clean up and exit
+	if (window.rangoInterceptorLoaded) {
+		document.querySelector("#rango-clipboard-write-interceptor")?.remove();
+		return;
 	}
 
-	if (event.data.type === "RANGO_STOP_CLIPBOARD_WRITE_INTERCEPTION") {
-		stopClipboardWriteInterception();
-	}
+	window.rangoInterceptorLoaded = true;
 
-	if (event.data.type === "RANGO_CHECK_INTERCEPTOR_LOADED") {
+	// Capture the real browser APIs (only happens once, on first load)
+	const originalDocumentExecCommand = document.execCommand;
+	const originalClipboardWrite = window.navigator.clipboard.write;
+	const originalClipboardWriteText = window.navigator.clipboard.writeText;
+
+	window.addEventListener("message", (event) => {
+		if (event.origin !== window.location.origin) return;
+
+		if (event.data.type === "RANGO_START_CLIPBOARD_WRITE_INTERCEPTION") {
+			startClipboardWriteInterception();
+		}
+
+		if (event.data.type === "RANGO_STOP_CLIPBOARD_WRITE_INTERCEPTION") {
+			stopClipboardWriteInterception();
+		}
+
+		if (event.data.type === "RANGO_CHECK_INTERCEPTOR_LOADED") {
+			window.postMessage(
+				{ type: "RANGO_INTERCEPTOR_LOADED" },
+				window.location.origin
+			);
+		}
+	});
+
+	function startClipboardWriteInterception() {
+		window.navigator.clipboard.write = async () => {
+			postMessageClipboardWriteIntercepted();
+			stopClipboardWriteInterception();
+		};
+
+		window.navigator.clipboard.writeText = async (text) => {
+			postMessageClipboardWriteIntercepted(text);
+			stopClipboardWriteInterception();
+		};
+
+		document.execCommand = (...args) => {
+			if (args[0] === "copy") {
+				postMessageClipboardWriteIntercepted(window.getSelection()?.toString());
+				stopClipboardWriteInterception();
+				return;
+			}
+
+			originalDocumentExecCommand.apply(document, args);
+		};
+
 		window.postMessage(
-			{ type: "RANGO_INTERCEPTOR_LOADED" },
+			{ type: "RANGO_CLIPBOARD_WRITE_INTERCEPTION_READY" },
 			window.location.origin
 		);
 	}
-});
 
-function startClipboardWriteInterception() {
-	window.navigator.clipboard.write = async () => {
-		postMessageClipboardWriteIntercepted();
-		stopClipboardWriteInterception();
-	};
+	function stopClipboardWriteInterception() {
+		document.execCommand = originalDocumentExecCommand;
+		window.navigator.clipboard.write = originalClipboardWrite;
+		window.navigator.clipboard.writeText = originalClipboardWriteText;
+	}
 
-	window.navigator.clipboard.writeText = async (text) => {
-		postMessageClipboardWriteIntercepted(text);
-		stopClipboardWriteInterception();
-	};
+	function postMessageClipboardWriteIntercepted(text) {
+		window.postMessage(
+			{ type: "RANGO_CLIPBOARD_WRITE_INTERCEPTED", text },
+			window.location.origin
+		);
+	}
 
-	document.execCommand = (...args) => {
-		if (args[0] === "copy") {
-			postMessageClipboardWriteIntercepted(window.getSelection()?.toString());
-			stopClipboardWriteInterception();
-			return;
-		}
-
-		originalDocumentExecCommand.apply(document, args);
-	};
+	document.querySelector("#rango-clipboard-write-interceptor").remove();
 
 	window.postMessage(
-		{ type: "RANGO_CLIPBOARD_WRITE_INTERCEPTION_READY" },
+		{ type: "RANGO_INTERCEPTOR_LOADED" },
 		window.location.origin
 	);
-}
-
-function stopClipboardWriteInterception() {
-	document.execCommand = originalDocumentExecCommand;
-	window.navigator.clipboard.write = originalClipboardWrite;
-	window.navigator.clipboard.writeText = originalClipboardWriteText;
-}
-
-function postMessageClipboardWriteIntercepted(text) {
-	window.postMessage(
-		{ type: "RANGO_CLIPBOARD_WRITE_INTERCEPTED", text },
-		window.location.origin
-	);
-}
-
-document.querySelector("#rango-clipboard-write-interceptor").remove();
-
-window.postMessage(
-	{ type: "RANGO_INTERCEPTOR_LOADED" },
-	window.location.origin
-);
+})();


### PR DESCRIPTION
This fixes an issue that I saw in Rango last year, but I'm unable to reproduce anymore, probably because Gmail itself has changed. The bug was that when I would dictate into Gmail to compose an email, it would sporadically enter the text twice. This started right after I began using Rango. I added a bunch of debug logs and discovered that when this happened, the clipboard interceptor was being injected multiple times and the original API was not being restored properly. I'm not sure exactly what sequence of events caused this and why it would trigger that exact behavior, but looking at the code I could see that there was no protection against multiple injections of the script, e.g. if multiple clipboard buttons on a page were clicked. Even without the case where the original handlers are overridden, it seems like a bug that this could install multiple identical listeners.

In this last week I've been testing without this fix and I haven't been able to reproduce the original "double-paste" issue in Gmail, so it's up to you whether you want to merge this, but it seemed like a good cleanup regardless. I have tested this against clipboard buttons in webpages (e.g. on GitHub).

Here is how Claude describes the fix:

The clipboard write interceptor script could be injected multiple times on the same page (e.g., rapid clicks on copy buttons, SPA navigation). Each injection added a new message listener and captured the current clipboard APIs as "originals". If injection occurred while APIs were already patched, the second listener would capture patched functions as its "originals", causing API corruption when cleanup restored them.

Fix: Add a guard that prevents re-injection entirely. When the script detects it has already been loaded (via window.rangoInterceptorLoaded), it cleans up the script element and exits immediately. This ensures:
- Only one message listener exists
- Original APIs are captured exactly once (the real browser APIs)
- No listener accumulation across multiple clicks

Also wraps the script in an IIFE to enable early return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)