### PR TITLE
Add compact tab marker delimiter setting

### DIFF
--- a/e2e/decorateTitle.test.ts
+++ b/e2e/decorateTitle.test.ts
@@ -1,3 +1,4 @@
+import { setSetting } from "./utils/serviceWorker";
 import { sleep } from "./utils/testHelpers";
 
 // There is another tab open before the current one that also gets a marker.
@@ -6,6 +7,11 @@ const tabMarker = "B";
 
 beforeAll(async () => {
 	await page.goto("http://localhost:8080/basic.html");
+});
+
+afterAll(async () => {
+	// Reset setting to default
+	await setSetting("useCompactTabMarkerDelimiter", false);
 });
 
 test("The URL and the tab marker are attached to the title", async () => {
@@ -46,5 +52,17 @@ test("If the hash changes the URL in the title is updated", async () => {
 
 	expect(title).toBe(
 		`${tabMarker} | Document - http://localhost:8080/new.html#first`
+	);
+});
+
+test("Compact delimiter removes spaces around the | separator", async () => {
+	await setSetting("useCompactTabMarkerDelimiter", true);
+	await page.goto("http://localhost:8080/basic.html");
+	await sleep(500);
+
+	const title = await page.title();
+
+	expect(title).toBe(
+		`${tabMarker}|Document - http://localhost:8080/basic.html`
 	);
 });

--- a/e2e/utils/serviceWorker.ts
+++ b/e2e/utils/serviceWorker.ts
@@ -39,3 +39,13 @@ export async function runTestRequest(request: string) {
 		dispatchEvent(new CustomEvent("handle-test-request"));
 	}, request);
 }
+
+export async function setSetting<T>(key: string, value: T) {
+	const worker = await getServiceWorker();
+	await worker.evaluate(
+		async ({ key, value }) => {
+			await chrome.storage.sync.set({ [key]: value });
+		},
+		{ key, value }
+	);
+}

--- a/src/background/tabs/tabMarkers.ts
+++ b/src/background/tabs/tabMarkers.ts
@@ -191,7 +191,8 @@ function createTabMarkers(): TabMarkers {
 }
 
 function getMarkerFromTitle(title: string) {
-	return /^([a-z]{1,2}) \| /i.exec(title)?.[1]?.toLowerCase();
+	// Extract tab marker (matches both "A|" and "A | " formats)
+	return /^([a-z]{1,2}) ?\| ?/i.exec(title)?.[1]?.toLowerCase();
 }
 
 function isTabWithId(

--- a/src/common/settings/settingsSchema.ts
+++ b/src/common/settings/settingsSchema.ts
@@ -147,6 +147,7 @@ export const settingsSchema = z.object({
 	includeTabMarkers: z.boolean().default(true),
 	hideTabMarkersWithGlobalHintsOff: z.boolean().default(false),
 	uppercaseTabMarkers: z.boolean().default(true),
+	useCompactTabMarkerDelimiter: z.boolean().default(false),
 	keyboardClicking: z.boolean().default(false),
 	keysToExclude: z
 		.array(z.tuple([z.string(), z.string()]))

--- a/src/content/setup/decorateTitle.ts
+++ b/src/content/setup/decorateTitle.ts
@@ -76,9 +76,8 @@ async function removeDecorations(title: string) {
 		title = title.slice(0, -possibleSuffix.length);
 	}
 
-	// If document.title is empty, the space after the "|" might have been removed
-	// when removing the suffix. That's why it's optional.
-	return title.replace(/^[a-z]{1,2} \| ?/i, "");
+	// Remove tab marker prefix (matches both "A|" and "A | " formats)
+	return title.replace(/^[a-z]{1,2} ?\| ?/i, "");
 }
 
 async function getTitlePrefix() {
@@ -91,7 +90,10 @@ async function getTitlePrefix() {
 		? tabMarker.toUpperCase()
 		: tabMarker;
 
-	return `${marker} | `;
+	const delimiter = settingsSync.get("useCompactTabMarkerDelimiter")
+		? "|"
+		: " | ";
+	return `${marker}${delimiter}`;
 }
 
 function getTitleSuffix() {
@@ -136,6 +138,7 @@ settingsSync.onChange(
 		"includeTabMarkers",
 		"uppercaseTabMarkers",
 		"hideTabMarkersWithGlobalHintsOff",
+		"useCompactTabMarkerDelimiter",
 	],
 	updateTitleDecorations
 );

--- a/src/pages/settings/SettingsComponent.tsx
+++ b/src/pages/settings/SettingsComponent.tsx
@@ -265,6 +265,31 @@ export function SettingsComponent() {
 						)}
 					</Toggle>
 				</SettingRow>
+
+				<SettingRow>
+					<Toggle
+						label="Use compact tab marker delimiter"
+						isPressed={dirtySettings.useCompactTabMarkerDelimiter}
+						isDisabled={!dirtySettings.includeTabMarkers}
+						onClick={() => {
+							handleChange(
+								"useCompactTabMarkerDelimiter",
+								!dirtySettings.useCompactTabMarkerDelimiter
+							);
+						}}
+					>
+						{dirtySettings.includeTabMarkers ? (
+							<p className="explanation">
+								Use &quot;|&quot; instead of &quot; | &quot; as the delimiter.
+							</p>
+						) : (
+							<p className="explanation">
+								This setting is disabled while tab markers in title are
+								disabled.
+							</p>
+						)}
+					</Toggle>
+				</SettingRow>
 			</SettingsGroup>
 
 			<SettingsGroup label="Hints appearance">


### PR DESCRIPTION
I find that with many tabs open, I cannot tell which is which because the only part shown is the tab marker. This adds a toggle (off by default) that switches the tab marker delimiter from " | " to "|" for users who prefer a more compact format.