### PR TITLE
Fix hint reattach failing in production due to closed shadow DOM

### DIFF
--- a/src/content/hints/Hint.ts
+++ b/src/content/hints/Hint.ts
@@ -194,10 +194,11 @@ const containerMutationObserver = new MutationObserver((entries) => {
 	for (const entry of entries) {
 		for (const node of entry.removedNodes) {
 			if (node instanceof HTMLDivElement && node.className === "rango-hint") {
-				const inner = node.shadowRoot?.querySelector(".inner");
+				// Avoid node.shadowRoot (closed shadow DOM in production).
+				const label = node.dataset["hint"];
 
-				if (inner?.textContent) {
-					const wrapper = getWrapper(inner.textContent);
+				if (label) {
+					const wrapper = getWrapper(label);
 
 					// eslint-disable-next-line max-depth
 					if (wrapper?.hint?.label) {


### PR DESCRIPTION
Google Calendar event popups sometimes showed no Rango hints. containerMutationObserver used node.shadowRoot to read the hint label, but shadowRoot returns null for closed shadow DOM (production builds), silently preventing hint reattachment. Use the data-hint attribute on the shadow host instead, which is set unconditionally during processHintQueue.