### PR TITLE
Update focus and textarea label in ExportSettingsDialog.tsx

### DIFF
--- a/src/pages/settings/ExportSettingsDialog.tsx
+++ b/src/pages/settings/ExportSettingsDialog.tsx
@@ -59,10 +59,11 @@ export function ExportSettingsDialog({
 				}}
 			>
 				<h3>Export Settings</h3>
-				<textarea readOnly value={JSON.stringify(settings, null, 2)} />
+				<textarea readOnly value={JSON.stringify(settings, null, 2)} placeholder="Settings export" />
 				<div className="buttons">
 					<button
 						type="button"
+						autoFocus
 						className={`copy ${copied ? "copied" : ""}`}
 						onClick={handleCopyToClipboard}
 					>

--- a/src/pages/settings/ExportSettingsDialog.tsx
+++ b/src/pages/settings/ExportSettingsDialog.tsx
@@ -61,8 +61,8 @@ export function ExportSettingsDialog({
 				<h3>Export Settings</h3>
 				<textarea
 					readOnly
-					value={JSON.stringify(settings, null, 2)} 
-					placeholder="Settings export" 
+					value={JSON.stringify(settings, null, 2)}
+					placeholder="Settings export"
 				/>
 				<div className="buttons">
 					<button

--- a/src/pages/settings/ExportSettingsDialog.tsx
+++ b/src/pages/settings/ExportSettingsDialog.tsx
@@ -59,11 +59,15 @@ export function ExportSettingsDialog({
 				}}
 			>
 				<h3>Export Settings</h3>
-				<textarea readOnly value={JSON.stringify(settings, null, 2)} placeholder="Settings export" />
+				<textarea
+					readOnly
+					value={JSON.stringify(settings, null, 2)} 
+					placeholder="Settings export" 
+				/>
 				<div className="buttons">
 					<button
-						type="button"
 						autoFocus
+						type="button"
 						className={`copy ${copied ? "copied" : ""}`}
 						onClick={handleCopyToClipboard}
 					>


### PR DESCRIPTION
The export dialog doesn't receive focus automatically right now. This adds autoFocus to the copy button which not only moves focus into the dialog but also moves it to a reasonable spot. I also added placeholder text on the settings export text area. This serves as a label for screen readers to indicate what's contained while still allowing them to move into the box to access the content. The string is otherwise invisible to other users since the box has content.