### PR TITLE
Add CLI transport MVP (daemon bridge + native messaging)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,15 @@ jobs:
       - run: npm ci
       - run: npm run check-format
       - run: npm test
+  test-daemon:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - uses: oven-sh/setup-bun@v2
+      - run: npx tsc --noemit -p tsconfig.bun.json
+      - run: bun run test:daemon

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## CLI transport (daemon / cli / shared)
+
+This repo ships a second, independent codepath alongside the browser
+extension: a CLI transport that drives Rango's hint navigation from the
+command line. It lives in three top-level directories that are **not**
+part of the Parcel-bundled extension build:
+
+- `shared/` — wire protocol (`protocol.ts`), frame codec (`frame.ts`), and
+  shared filesystem paths (`platform.ts`), used by both `daemon/` and
+  `cli/`.
+- `daemon/` — a Bun-based host companion daemon. It exposes an HTTP API
+  (`GET /health`, `POST /command`) for the CLI leg, and bridges to the
+  extension over Chrome/Firefox's native-messaging stdio protocol (4-byte
+  little-endian length-prefixed JSON frames) for the extension leg.
+- `cli/` — the `rango-cli` binary. Auto-spawns the daemon if one isn't
+  already running, then POSTs commands to it over HTTP.
+
+Run with Bun, not Node: `npm run daemon`, `npm run cli`, `npm run
+test:daemon`. Typecheck this code with `npm run check-types:daemon` (a
+separate `tsconfig.bun.json`, not the root `tsconfig.json` — the root
+config is scoped to the browser-extension code and excludes these three
+directories, since they need Bun's globals/types and top-level `await`
+rather than the extension's DOM-flavored config).
+
+### Why a daemon instead of the extension serving HTTP directly
+
+MV3 service workers cannot serve HTTP. The daemon is a separate host
+process (installed as a native-messaging host) that bridges the CLI's
+HTTP requests to the extension's native-messaging port. This mirrors the
+architecture of the sibling `Interceptor` project.
+
+### Singleton / relay pattern
+
+Chrome/Firefox spawn a fresh native-messaging host process every time the
+extension calls `connectNative()` — e.g. once per browser window/profile
+that has Rango open. Only one process may own the CLI-facing HTTP port
+and PID/port files at a time. `daemon/lifecycle.ts` and `daemon/index.ts`
+implement a two-layer election, mirroring Interceptor:
+
+1. **Advisory**: a PID file records the presumed singleton. A stale PID
+   file (dead process) doesn't block a new singleton from taking over.
+2. **Authoritative**: real exclusivity comes from binding the control
+   socket (`Bun.listen({unix: ...})`). Whichever process wins that bind
+   is the singleton.
+
+A process that loses the election does not exit or duplicate state —
+it becomes a **transparent byte relay** (`daemon/relay.ts`): it pipes raw
+framed bytes between its own stdio (the browser's native-messaging pipe
+for that window) and the singleton's control socket. The singleton's
+`ExtensionBridge` (`daemon/extensionBridge.ts`) is agnostic to whether its
+writer is its own stdio or a relayed control-socket connection — both
+speak the same frame format, so multiple browser windows can each hold a
+native-messaging connection while only one process does protocol work.
+
+### Command reuse, not new commands
+
+`cli/commands.ts` maps CLI verbs onto Rango's **existing** `ActionMap`
+entries (`enableHints`, `refreshHints`, `disableHints`, `clickElement`)
+dispatched through the existing `handleCommand()` in
+`src/background/commands/commandHandler.ts` — the same dispatcher the
+clipboard/Talon transport already uses. No new Action types were added.
+Hint visibility uses `enableHints({level: "now"})`, the existing
+rendering-coupled overlay (`Hint.ts`) at Rango's ephemeral toggle level —
+this is intentionally the temporary-overlay MVP path, not a headless
+hint-computation path (that would be a separate follow-up).
+
+### Testing without a live browser
+
+`daemon/*.test.ts` and `cli/*.integration.test.ts` mock the extension leg
+by connecting directly to the daemon's control socket (the same
+Unix-socket API a relayed browser process would use) and speaking the
+same frame protocol by hand. The integration tests spawn the *real*
+`daemon/index.ts --standalone` and `cli/index.ts` binaries as
+subprocesses (via `Bun.spawn`) rather than importing their internals, so
+they exercise the actual CLI-to-daemon-to-extension round trip end to
+end. Run with `bun test daemon cli shared` (or `npm run test:daemon`).
+
+Each test file that touches `shared/platform.ts` (which reads
+`RANGO_HOME` at import time) isolates itself with its own temp directory.
+Only one test file may import `shared/platform`/`daemon/lifecycle`
+directly per `bun test` process, since Bun's module cache means a second
+file importing it would see the first file's `RANGO_HOME`, not its own —
+other test files that need an isolated daemon instance compute the
+expected paths manually (`path.join(tempHome, "daemon.port")`, etc.)
+instead of importing `shared/platform`.
+
+### Browser scope
+
+Chrome and Firefox only. Safari uses a fundamentally different
+native-messaging API (`NSExtensionRequest`, not a stdio host process)
+and is out of scope for this transport — `isSafari()` gates
+`connectNativeHost()` in `src/background/background.ts` so the native
+messaging connection is never attempted there.
+
+## Maintaining this file
+
+Keep this file scoped to knowledge that isn't obvious from reading the
+code itself: cross-cutting architectural decisions, non-obvious
+constraints, and *why* something is structured the way it is. Update it
+when you make a decision future agents would otherwise have to
+rediscover by reading a stack trace or a PR discussion. Don't restate
+what a docstring or file layout already makes clear.

--- a/cli/cli.integration.test.ts
+++ b/cli/cli.integration.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { encodeFrame, FrameDecoder } from "../shared/frame";
+
+/**
+ * Exercises the real rango-cli binary end to end: CLI -> daemon (auto-spawned
+ * by the CLI itself, mirroring real usage) -> control socket -> mock
+ * extension -> response -> CLI stdout. Paths are computed manually rather
+ * than imported from shared/platform, for the same import-time-env-var
+ * reason documented in daemon/daemon.integration.test.ts.
+ */
+
+const repoRoot = path.join(import.meta.dir, "..");
+const cliEntry = path.join(repoRoot, "cli", "index.ts");
+
+let tempHome: string;
+let mockExtensionSocket: Bun.Socket<undefined> | undefined;
+
+function paths(home: string) {
+	return {
+		pidFile: path.join(home, "daemon.pid"),
+		portFile: path.join(home, "daemon.port"),
+		controlSocketPath: path.join(home, "daemon.sock"),
+	};
+}
+
+async function waitFor(
+	check: () => boolean | Promise<boolean>,
+	timeoutMs = 10_000
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await check()) return;
+		await Bun.sleep(50);
+	}
+
+	throw new Error("Timed out waiting for condition.");
+}
+
+async function runCli(
+	...args: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const proc = Bun.spawn(["bun", "run", cliEntry, ...args], {
+		cwd: repoRoot,
+		env: { ...process.env, RANGO_HOME: tempHome },
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+
+	return { stdout, stderr, exitCode };
+}
+
+beforeAll(async () => {
+	tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "rango-cli-it-"));
+});
+
+afterAll(() => {
+	mockExtensionSocket?.end();
+
+	const { pidFile } = paths(tempHome);
+	try {
+		const pid = Number(fs.readFileSync(pidFile, "utf8").trim());
+		if (Number.isFinite(pid)) process.kill(pid, "SIGTERM");
+	} catch {
+		// No daemon left running; nothing to clean up.
+	}
+
+	fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("rango-cli status", () => {
+	test("auto-spawns the daemon and prints its port", async () => {
+		const { stdout, exitCode } = await runCli("status");
+
+		expect(exitCode).toBe(0);
+		const body = JSON.parse(stdout.trim());
+		expect(body.ok).toBe(true);
+		expect(typeof body.port).toBe("number");
+	});
+});
+
+describe("rango-cli click <label>", () => {
+	test("round-trips through the auto-spawned daemon and a mock extension", async () => {
+		const { controlSocketPath } = paths(tempHome);
+		const decoder = new FrameDecoder();
+
+		await waitFor(async () => {
+			try {
+				mockExtensionSocket = await Bun.connect({
+					unix: controlSocketPath,
+					socket: {
+						data(socket, chunk) {
+							for (const message of decoder.push(chunk)) {
+								const request = message as {
+									id: string;
+									action: { name: string; [key: string]: unknown };
+								};
+								socket.write(
+									encodeFrame({
+										id: request.id,
+										success: true,
+										data: { clicked: request.action["target"] },
+									})
+								);
+							}
+						},
+						open() {},
+						close() {},
+						error() {},
+					},
+				});
+				return true;
+			} catch {
+				return false;
+			}
+		});
+
+		const { stdout, stderr, exitCode } = await runCli("click", "aa");
+
+		expect(stderr).toBe("");
+		expect(exitCode).toBe(0);
+		const body = JSON.parse(stdout.trim());
+		expect(body.clicked).toEqual({
+			type: "primitive",
+			mark: { type: "elementHint", value: "AA" },
+		});
+	});
+});
+
+describe("rango-cli with no arguments", () => {
+	test("prints usage and exits 0", async () => {
+		const { stdout, exitCode } = await runCli();
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain("rango-cli");
+	});
+});
+
+describe("rango-cli click with no label", () => {
+	test("fails with a usage error", async () => {
+		const { stderr, exitCode } = await runCli("click");
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("Usage:");
+	});
+});

--- a/cli/commands.ts
+++ b/cli/commands.ts
@@ -1,0 +1,32 @@
+import type { CommandAction } from "../shared/protocol";
+
+/**
+ * Maps rango-cli verbs to Rango's existing `ActionMap` command names — the
+ * same commands the clipboard/Talon transport already dispatches through
+ * `handleCommand()`. The MVP intentionally reuses `enableHints({level:"now"})`
+ * + `refreshHints()` (the existing rendering-coupled overlay) rather than
+ * adding a headless hint-computation path.
+ */
+export const showHintsAction: CommandAction = {
+	name: "enableHints",
+	level: "now",
+};
+
+export const refreshHintsAction: CommandAction = { name: "refreshHints" };
+
+export const hideHintsAction: CommandAction = {
+	name: "disableHints",
+	level: "now",
+};
+
+export function clickHintAction(label: string): CommandAction {
+	if (!label) throw new Error("Usage: rango click <hint-label>");
+
+	return {
+		name: "clickElement",
+		target: {
+			type: "primitive",
+			mark: { type: "elementHint", value: label.toUpperCase() },
+		},
+	};
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env bun
+import {
+	clickHintAction,
+	hideHintsAction,
+	refreshHintsAction,
+	showHintsAction,
+} from "./commands";
+import { ensureDaemon, sendCommand, type CommandResult } from "./transport";
+
+const USAGE = `rango-cli — drive Rango hint navigation from the command line
+
+Usage:
+  rango-cli status                Start/check the daemon and print its port
+  rango-cli hints show            Enable hints (temporary overlay)
+  rango-cli hints hide            Disable hints
+  rango-cli click <hint-label>    Click the element under a hint label
+  rango-cli navigate <hint-label> Show hints, then click one (end-to-end)
+`;
+
+async function run(action: { name: string; [key: string]: unknown }) {
+	const result = await sendCommand(action);
+	if (!result.success) {
+		throw new Error(result.error ?? `Command "${action.name}" failed.`);
+	}
+
+	return result;
+}
+
+function printResult(result: CommandResult) {
+	if (result.success && result.data !== undefined) {
+		console.log(JSON.stringify(result.data));
+	}
+}
+
+async function main() {
+	const [command, ...rest] = process.argv.slice(2);
+
+	switch (command) {
+		case "status": {
+			const port = await ensureDaemon();
+			console.log(JSON.stringify({ ok: true, port }));
+			return;
+		}
+
+		case "hints": {
+			const sub = rest[0];
+			if (sub === "show") {
+				await run(showHintsAction);
+				printResult(await run(refreshHintsAction));
+			} else if (sub === "hide") {
+				await run(hideHintsAction);
+			} else {
+				throw new Error("Usage: rango-cli hints <show|hide>");
+			}
+
+			return;
+		}
+
+		case "click": {
+			printResult(await run(clickHintAction(rest[0] ?? "")));
+			return;
+		}
+
+		case "navigate": {
+			await run(showHintsAction);
+			await run(refreshHintsAction);
+			// Give the overlay a moment to render before targeting a hint.
+			await Bun.sleep(150);
+			printResult(await run(clickHintAction(rest[0] ?? "")));
+			return;
+		}
+
+		default: {
+			console.log(USAGE);
+			process.exitCode = command ? 1 : 0;
+		}
+	}
+}
+
+try {
+	await main();
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+}

--- a/cli/transport.ts
+++ b/cli/transport.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+import { platform, REQUEST_TIMEOUT_MS } from "../shared/platform";
+import { isProcessAlive, readPidFile, readPortFile } from "../daemon/lifecycle";
+
+const daemonEntry = path.join(import.meta.dir, "..", "daemon", "index.ts");
+
+async function pingHealth(port: number): Promise<boolean> {
+	try {
+		const response = await fetch(`http://127.0.0.1:${port}/health`, {
+			signal: AbortSignal.timeout(1000),
+		});
+		return response.ok;
+	} catch {
+		return false;
+	}
+}
+
+async function spawnDaemon(): Promise<void> {
+	Bun.spawn(["bun", "run", daemonEntry, "--standalone"], {
+		stdio: ["ignore", "ignore", "ignore"],
+	}).unref();
+}
+
+async function waitForDaemon(timeoutMs = 5000): Promise<number> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const port = readPortFile();
+		if (port !== undefined && (await pingHealth(port))) return port;
+		await Bun.sleep(100);
+	}
+
+	throw new Error(
+		`Timed out waiting for the rango daemon to start. Check ${platform.logFile}.`
+	);
+}
+
+/** Finds a running daemon, or spawns one and waits for it to become healthy. */
+export async function ensureDaemon(): Promise<number> {
+	const pid = readPidFile();
+	const port = readPortFile();
+	if (pid !== undefined && port !== undefined && isProcessAlive(pid)) {
+		if (await pingHealth(port)) return port;
+	}
+
+	await spawnDaemon();
+	return waitForDaemon();
+}
+
+export type CommandResult =
+	| { id?: string; success: true; data?: unknown }
+	| { id?: string; success: false; error: string };
+
+export async function sendCommand(action: {
+	name: string;
+	[key: string]: unknown;
+}): Promise<CommandResult> {
+	const port = await ensureDaemon();
+	const response = await fetch(`http://127.0.0.1:${port}/command`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ action }),
+		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS + 2000),
+	});
+
+	return (await response.json()) as CommandResult;
+}

--- a/daemon/daemon.integration.test.ts
+++ b/daemon/daemon.integration.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { encodeFrame, FrameDecoder } from "../shared/frame";
+
+/**
+ * Spawns the real daemon binary and talks to it exactly as its two real
+ * clients would: HTTP for the CLI leg, and a raw socket connection standing
+ * in for "the extension" on the control-socket leg (the same leg a relayed
+ * browser-spawned process would use). No live browser is available in CI, so
+ * this mock socket client is the substitute the acceptance criteria call for.
+ *
+ * Deliberately avoids importing shared/platform or daemon/lifecycle here:
+ * those modules read RANGO_HOME at import time, and daemon/lifecycle.test.ts
+ * (which runs in the same bun test process) imports them under a different
+ * RANGO_HOME. Paths below are computed manually to match shared/platform.ts.
+ */
+
+const repoRoot = path.join(import.meta.dir, "..");
+const daemonEntry = path.join(repoRoot, "daemon", "index.ts");
+
+let tempHome: string;
+let daemonProcess: ReturnType<typeof Bun.spawn>;
+let port: number;
+
+function paths(home: string) {
+	return {
+		pidFile: path.join(home, "daemon.pid"),
+		portFile: path.join(home, "daemon.port"),
+		controlSocketPath: path.join(home, "daemon.sock"),
+	};
+}
+
+async function waitFor(
+	check: () => boolean | Promise<boolean>,
+	timeoutMs = 10_000
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await check()) return;
+		await Bun.sleep(50);
+	}
+
+	throw new Error("Timed out waiting for condition.");
+}
+
+beforeAll(async () => {
+	tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "rango-daemon-it-"));
+
+	daemonProcess = Bun.spawn(["bun", "run", daemonEntry, "--standalone"], {
+		cwd: repoRoot,
+		env: { ...process.env, RANGO_HOME: tempHome },
+		stdio: ["ignore", "ignore", "ignore"],
+	});
+
+	const { portFile } = paths(tempHome);
+	await waitFor(() => fs.existsSync(portFile));
+	port = Number(fs.readFileSync(portFile, "utf8").trim());
+
+	await waitFor(async () => {
+		try {
+			const response = await fetch(`http://127.0.0.1:${port}/health`);
+			return response.ok;
+		} catch {
+			return false;
+		}
+	});
+});
+
+afterAll(() => {
+	daemonProcess.kill();
+	fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("GET /health", () => {
+	test("reports the daemon pid and no extension connected yet", async () => {
+		const response = await fetch(`http://127.0.0.1:${port}/health`);
+		const body = await response.json();
+
+		expect(response.ok).toBe(true);
+		expect(body).toMatchObject({ ok: true, extensionConnected: false });
+		expect(typeof body.pid).toBe("number");
+	});
+});
+
+describe("POST /command with no extension connected", () => {
+	test("responds 503", async () => {
+		const response = await fetch(`http://127.0.0.1:${port}/command`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ action: { name: "refreshHints" } }),
+		});
+
+		expect(response.status).toBe(503);
+		const body = await response.json();
+		expect(body.success).toBe(false);
+	});
+});
+
+describe("POST /command with a malformed body", () => {
+	test("responds 400", async () => {
+		const response = await fetch(`http://127.0.0.1:${port}/command`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ notAnAction: true }),
+		});
+
+		expect(response.status).toBe(400);
+	});
+});
+
+describe("full round trip through a mock extension on the control socket", () => {
+	test("relays the request and returns the mock extension's response", async () => {
+		const { controlSocketPath } = paths(tempHome);
+		const decoder = new FrameDecoder();
+		let socket: Bun.Socket<undefined> | undefined;
+
+		await waitFor(async () => {
+			try {
+				socket = await Bun.connect({
+					unix: controlSocketPath,
+					socket: {
+						data(_socket, chunk) {
+							for (const message of decoder.push(chunk)) {
+								const request = message as {
+									id: string;
+									action: { name: string; [key: string]: unknown };
+								};
+								socket!.write(
+									encodeFrame({
+										id: request.id,
+										success: true,
+										data: { echoed: request.action.name },
+									})
+								);
+							}
+						},
+						open() {},
+						close() {},
+						error() {},
+					},
+				});
+				return true;
+			} catch {
+				return false;
+			}
+		});
+
+		await waitFor(async () => {
+			const response = await fetch(`http://127.0.0.1:${port}/health`);
+			const body = await response.json();
+			return body.extensionConnected === true;
+		});
+
+		const response = await fetch(`http://127.0.0.1:${port}/command`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				action: { name: "clickElement", target: "A" },
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toMatchObject({
+			success: true,
+			data: { echoed: "clickElement" },
+		});
+
+		socket!.end();
+	});
+});

--- a/daemon/extensionBridge.test.ts
+++ b/daemon/extensionBridge.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { encodeFrame, FrameDecoder } from "../shared/frame";
+import { ExtensionBridge } from "./extensionBridge";
+
+describe("ExtensionBridge", () => {
+	test("reports disconnected with no writer attached", async () => {
+		const bridge = new ExtensionBridge(1000);
+		expect(bridge.connected).toBe(false);
+
+		const result = await bridge.send({ name: "clickElement" });
+		expect(result).toEqual({
+			id: "",
+			success: false,
+			error: "No extension connected.",
+		});
+	});
+
+	test("sends a framed request and resolves on a matching framed response", async () => {
+		const bridge = new ExtensionBridge(1000);
+		const written: Uint8Array[] = [];
+		bridge.attach((chunk) => written.push(chunk));
+
+		const resultPromise = bridge.send({ name: "clickElement", target: "x" });
+
+		expect(written).toHaveLength(1);
+		const decoder = new FrameDecoder();
+		const [sent] = decoder.push(written[0]!) as [
+			{ id: string; action: { name: string; target?: string } },
+		];
+		expect(sent.action).toEqual({ name: "clickElement", target: "x" });
+
+		bridge.handleIncomingBytes(
+			encodeFrame({ id: sent.id, success: true, data: { clicked: true } })
+		);
+
+		await expect(resultPromise).resolves.toEqual({
+			id: sent.id,
+			success: true,
+			data: { clicked: true },
+		});
+	});
+
+	test("detach rejects in-flight requests and flips connected to false", async () => {
+		const bridge = new ExtensionBridge(1000);
+		bridge.attach(() => {});
+		const resultPromise = bridge.send({ name: "refreshHints" });
+
+		bridge.detach();
+
+		expect(bridge.connected).toBe(false);
+		const result = await resultPromise;
+		expect(result.success).toBe(false);
+	});
+
+	test("assembles a response split across multiple incoming chunks", async () => {
+		const bridge = new ExtensionBridge(1000);
+		const written: Uint8Array[] = [];
+		bridge.attach((chunk) => written.push(chunk));
+
+		const resultPromise = bridge.send({ name: "clickElement" });
+
+		const decoder = new FrameDecoder();
+		const [sent] = decoder.push(written[0]!) as [{ id: string }];
+		const frame = Buffer.from(encodeFrame({ id: sent.id, success: true }));
+
+		bridge.handleIncomingBytes(frame.subarray(0, 4));
+		bridge.handleIncomingBytes(frame.subarray(4));
+
+		await expect(resultPromise).resolves.toEqual({
+			id: sent.id,
+			success: true,
+		});
+	});
+});

--- a/daemon/extensionBridge.ts
+++ b/daemon/extensionBridge.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from "node:crypto";
+import { encodeFrame, FrameDecoder } from "../shared/frame";
+import {
+	type CommandAction,
+	type ExtensionToDaemonResponse,
+	isExtensionResponse,
+} from "../shared/protocol";
+import { PendingRequests } from "./pendingRequests";
+
+type Writer = (chunk: Uint8Array) => void;
+
+/**
+ * The daemon's one connection to "the extension" — whether that byte stream
+ * is this process's own stdio (spawned directly by the browser as the native
+ * host) or a relayed control-socket connection (forwarded from a sibling
+ * process the browser spawned while this singleton was already running) is
+ * transparent to this class; both speak the same length-prefixed JSON frames.
+ */
+export class ExtensionBridge {
+	private writer: Writer | undefined;
+	private readonly decoder = new FrameDecoder();
+	private readonly pending: PendingRequests;
+
+	constructor(timeoutMs: number) {
+		this.pending = new PendingRequests(timeoutMs);
+	}
+
+	get connected(): boolean {
+		return this.writer !== undefined;
+	}
+
+	attach(writer: Writer) {
+		this.writer = writer;
+	}
+
+	detach() {
+		this.writer = undefined;
+		this.pending.rejectAll("The extension disconnected.");
+	}
+
+	handleIncomingBytes(chunk: Uint8Array) {
+		for (const message of this.decoder.push(chunk)) {
+			if (isExtensionResponse(message)) this.pending.resolve(message);
+		}
+	}
+
+	async send(action: CommandAction): Promise<ExtensionToDaemonResponse> {
+		if (!this.writer) {
+			return { id: "", success: false, error: "No extension connected." };
+		}
+
+		const id = randomUUID();
+		const response = this.pending.register(id);
+		this.writer(encodeFrame({ id, action }));
+		return response;
+	}
+}

--- a/daemon/httpServer.ts
+++ b/daemon/httpServer.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { ExtensionBridge } from "./extensionBridge";
+
+const zCommandRequest = z.object({
+	action: z.object({ name: z.string() }).passthrough(),
+});
+
+export function createHttpServer(bridge: ExtensionBridge) {
+	return Bun.serve({
+		port: 0,
+		hostname: "127.0.0.1",
+		async fetch(request) {
+			const url = new URL(request.url);
+
+			if (url.pathname === "/health" && request.method === "GET") {
+				return Response.json({
+					ok: true,
+					pid: process.pid,
+					extensionConnected: bridge.connected,
+				});
+			}
+
+			if (url.pathname === "/command" && request.method === "POST") {
+				let body: unknown;
+				try {
+					body = await request.json();
+				} catch {
+					return Response.json(
+						{ success: false, error: "Invalid JSON body." },
+						{ status: 400 }
+					);
+				}
+
+				const parsed = zCommandRequest.safeParse(body);
+				if (!parsed.success) {
+					return Response.json(
+						{ success: false, error: "Expected { action: { name, ...} }." },
+						{ status: 400 }
+					);
+				}
+
+				if (!bridge.connected) {
+					return Response.json(
+						{
+							success: false,
+							error:
+								"No extension connected. Make sure Rango is loaded in a browser and has connected to the daemon.",
+						},
+						{ status: 503 }
+					);
+				}
+
+				const result = await bridge.send(parsed.data.action);
+				return Response.json(result, { status: result.success ? 200 : 502 });
+			}
+
+			return new Response("Not found", { status: 404 });
+		},
+	});
+}
+
+export type RangoDaemonHttpServer = ReturnType<typeof createHttpServer>;

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env bun
+import { REQUEST_TIMEOUT_MS } from "../shared/platform";
+import { ExtensionBridge } from "./extensionBridge";
+import { createHttpServer } from "./httpServer";
+import {
+	checkExistingSingleton,
+	ensureHomeDir,
+	removeControlSocketFile,
+	removePidFile,
+	removePortFile,
+	writePidFile,
+	writePortFile,
+} from "./lifecycle";
+import { runRelay, startControlSocketServer } from "./relay";
+
+async function main() {
+	ensureHomeDir();
+
+	const standalone = process.argv.includes("--standalone");
+	const existing = checkExistingSingleton();
+
+	if (existing.alive) {
+		if (standalone) {
+			console.log(`rango daemon already running (pid ${existing.pid}).`);
+			return;
+		}
+
+		// The browser spawned us as the native-messaging host, but a singleton
+		// is already serving the CLI's HTTP leg. Become a transparent relay.
+		await runRelay();
+		return;
+	}
+
+	await runSingleton(standalone);
+}
+
+async function runSingleton(standalone: boolean) {
+	writePidFile(process.pid);
+
+	const bridge = new ExtensionBridge(REQUEST_TIMEOUT_MS);
+	const server = createHttpServer(bridge);
+	if (server.port === undefined) {
+		throw new Error("Daemon HTTP server did not bind to a port.");
+	}
+
+	writePortFile(server.port);
+	const controlSocket = startControlSocketServer(bridge);
+
+	if (!standalone) {
+		// We were spawned directly by the browser as the native-messaging host;
+		// our own stdio *is* the extension connection.
+		process.stdin.on("data", (chunk: Buffer) => {
+			bridge.handleIncomingBytes(chunk);
+		});
+		process.stdin.on("close", () => {
+			bridge.detach();
+		});
+		bridge.attach((chunk) => {
+			process.stdout.write(chunk);
+		});
+	}
+
+	let shuttingDown = false;
+	const shutdown = () => {
+		if (shuttingDown) return;
+		shuttingDown = true;
+		removePidFile();
+		removePortFile();
+		removeControlSocketFile();
+		controlSocket.stop();
+		server.stop(true);
+		process.exit(0);
+	};
+
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
+
+	console.log(`rango daemon listening on http://127.0.0.1:${server.port}`);
+
+	// Keep the event loop alive; Bun.serve/Bun.listen alone don't block exit
+	// once stdin closes (e.g. after the browser tears down a native host).
+	await new Promise(() => {});
+}
+
+await main();

--- a/daemon/lifecycle.test.ts
+++ b/daemon/lifecycle.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// shared/platform.ts reads RANGO_HOME at import time, so it must be set
+// before the first import. This is the only test file that imports
+// shared/platform or daemon/lifecycle, so there's no risk of another file's
+// import caching a different RANGO_HOME first.
+const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "rango-lifecycle-"));
+process.env["RANGO_HOME"] = tempHome;
+
+const { platform } = await import("../shared/platform");
+const lifecycle = await import("./lifecycle");
+
+afterAll(() => {
+	fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("ensureHomeDir", () => {
+	test("creates the home directory", () => {
+		lifecycle.ensureHomeDir();
+		expect(fs.existsSync(platform.home)).toBe(true);
+	});
+});
+
+describe("pid file", () => {
+	test("round-trips and reports missing as undefined", () => {
+		lifecycle.removePidFile();
+		expect(lifecycle.readPidFile()).toBeUndefined();
+
+		lifecycle.writePidFile(12_345);
+		expect(lifecycle.readPidFile()).toBe(12_345);
+
+		lifecycle.removePidFile();
+		expect(lifecycle.readPidFile()).toBeUndefined();
+	});
+});
+
+describe("port file", () => {
+	test("round-trips and reports missing as undefined", () => {
+		lifecycle.removePortFile();
+		expect(lifecycle.readPortFile()).toBeUndefined();
+
+		lifecycle.writePortFile(54_321);
+		expect(lifecycle.readPortFile()).toBe(54_321);
+
+		lifecycle.removePortFile();
+		expect(lifecycle.readPortFile()).toBeUndefined();
+	});
+});
+
+describe("isProcessAlive", () => {
+	test("is true for the current process and false for a bogus pid", () => {
+		expect(lifecycle.isProcessAlive(process.pid)).toBe(true);
+		expect(lifecycle.isProcessAlive(999_999)).toBe(false);
+	});
+});
+
+describe("checkExistingSingleton", () => {
+	test("reports not alive when no pid file exists", () => {
+		lifecycle.removePidFile();
+		expect(lifecycle.checkExistingSingleton()).toEqual({ alive: false });
+	});
+
+	test("reports alive with the pid when the pid file points at a live process", () => {
+		lifecycle.writePidFile(process.pid);
+		expect(lifecycle.checkExistingSingleton()).toEqual({
+			alive: true,
+			pid: process.pid,
+		});
+		lifecycle.removePidFile();
+	});
+
+	test("treats a stale pid file as not alive", () => {
+		lifecycle.writePidFile(999_999);
+		expect(lifecycle.checkExistingSingleton()).toEqual({ alive: false });
+		lifecycle.removePidFile();
+	});
+});

--- a/daemon/lifecycle.ts
+++ b/daemon/lifecycle.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import { platform } from "../shared/platform";
+
+export function ensureHomeDir() {
+	fs.mkdirSync(platform.home, { recursive: true });
+}
+
+export function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function readPidFile(): number | undefined {
+	try {
+		const pid = Number(fs.readFileSync(platform.pidFile, "utf8").trim());
+		return Number.isFinite(pid) ? pid : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function writePidFile(pid: number) {
+	fs.writeFileSync(platform.pidFile, String(pid));
+}
+
+export function removePidFile() {
+	try {
+		fs.unlinkSync(platform.pidFile);
+	} catch {
+		// Nothing to remove.
+	}
+}
+
+export function readPortFile(): number | undefined {
+	try {
+		const port = Number(fs.readFileSync(platform.portFile, "utf8").trim());
+		return Number.isFinite(port) ? port : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function writePortFile(port: number) {
+	fs.writeFileSync(platform.portFile, String(port));
+}
+
+export function removePortFile() {
+	try {
+		fs.unlinkSync(platform.portFile);
+	} catch {
+		// Nothing to remove.
+	}
+}
+
+export function removeControlSocketFile() {
+	try {
+		fs.unlinkSync(platform.controlSocketPath);
+	} catch {
+		// Nothing to remove.
+	}
+}
+
+export type SingletonStatus = { alive: true; pid: number } | { alive: false };
+
+/**
+ * The PID file is advisory only (a process could die and leave a stale file).
+ * Real exclusivity comes from whichever process manages to bind the control
+ * socket first, mirroring Interceptor's two-layer singleton election.
+ */
+export function checkExistingSingleton(): SingletonStatus {
+	const pid = readPidFile();
+	if (pid !== undefined && isProcessAlive(pid)) return { alive: true, pid };
+	return { alive: false };
+}

--- a/daemon/pendingRequests.test.ts
+++ b/daemon/pendingRequests.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { PendingRequests } from "./pendingRequests";
+
+describe("PendingRequests", () => {
+	test("resolves a registered request when its response arrives", async () => {
+		const pending = new PendingRequests(1000);
+		const promise = pending.register("abc");
+
+		expect(pending.resolve({ id: "abc", success: true, data: 42 })).toBe(true);
+		await expect(promise).resolves.toEqual({
+			id: "abc",
+			success: true,
+			data: 42,
+		});
+		expect(pending.size).toBe(0);
+	});
+
+	test("ignores a response for an unknown or already-resolved id", () => {
+		const pending = new PendingRequests(1000);
+		pending.register("abc");
+		pending.resolve({ id: "abc", success: true });
+
+		expect(pending.resolve({ id: "abc", success: true })).toBe(false);
+		expect(pending.resolve({ id: "does-not-exist", success: true })).toBe(
+			false
+		);
+	});
+
+	test("times out a request that never gets a response", async () => {
+		const pending = new PendingRequests(10);
+		const promise = pending.register("abc");
+
+		const result = await promise;
+		expect(result.success).toBe(false);
+		expect(pending.size).toBe(0);
+	});
+
+	test("rejectAll resolves every pending request with the given error", async () => {
+		const pending = new PendingRequests(5000);
+		const a = pending.register("a");
+		const b = pending.register("b");
+
+		pending.rejectAll("extension disconnected");
+
+		expect(await a).toEqual({
+			id: "a",
+			success: false,
+			error: "extension disconnected",
+		});
+		expect(await b).toEqual({
+			id: "b",
+			success: false,
+			error: "extension disconnected",
+		});
+		expect(pending.size).toBe(0);
+	});
+});

--- a/daemon/pendingRequests.ts
+++ b/daemon/pendingRequests.ts
@@ -1,0 +1,56 @@
+import type { ExtensionToDaemonResponse } from "../shared/protocol";
+
+type Pending = {
+	resolve: (response: ExtensionToDaemonResponse) => void;
+	timer: ReturnType<typeof setTimeout>;
+};
+
+/**
+ * Correlates outgoing daemon->extension requests with their responses by id,
+ * with a per-request timeout. Native messaging (unlike Rango's old single-slot
+ * clipboard channel) supports genuine concurrency, so responses can't just be
+ * assumed to match the most recent request.
+ */
+export class PendingRequests {
+	private readonly pending = new Map<string, Pending>();
+
+	constructor(private readonly timeoutMs: number) {}
+
+	register(id: string): Promise<ExtensionToDaemonResponse> {
+		return new Promise((resolve) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				resolve({
+					id,
+					success: false,
+					error: "Timed out waiting for a response from the extension.",
+				});
+			}, this.timeoutMs);
+
+			this.pending.set(id, { resolve, timer });
+		});
+	}
+
+	resolve(response: ExtensionToDaemonResponse): boolean {
+		const entry = this.pending.get(response.id);
+		if (!entry) return false;
+
+		clearTimeout(entry.timer);
+		this.pending.delete(response.id);
+		entry.resolve(response);
+		return true;
+	}
+
+	rejectAll(error: string) {
+		for (const [id, entry] of this.pending) {
+			clearTimeout(entry.timer);
+			entry.resolve({ id, success: false, error });
+		}
+
+		this.pending.clear();
+	}
+
+	get size() {
+		return this.pending.size;
+	}
+}

--- a/daemon/relay.ts
+++ b/daemon/relay.ts
@@ -1,0 +1,70 @@
+import { platform } from "../shared/platform";
+import { removeControlSocketFile } from "./lifecycle";
+import type { ExtensionBridge } from "./extensionBridge";
+
+/**
+ * Runs in the singleton process. Accepts the one connection standing in for
+ * "the extension" — either a relayed browser-spawned process's stdio, or (in
+ * tests) a direct socket connection standing in for the extension leg.
+ */
+export function startControlSocketServer(bridge: ExtensionBridge) {
+	removeControlSocketFile();
+
+	return Bun.listen({
+		unix: platform.controlSocketPath,
+		socket: {
+			open(socket) {
+				bridge.attach((chunk) => {
+					socket.write(chunk);
+				});
+			},
+			data(_socket, chunk) {
+				bridge.handleIncomingBytes(chunk);
+			},
+			close() {
+				bridge.detach();
+			},
+			error(_socket, error) {
+				console.error("rango daemon: control socket error", error);
+			},
+		},
+	});
+}
+
+/**
+ * Runs in a process the browser spawned as the native-messaging host while a
+ * singleton was already running. Does no protocol-level work of its own — it
+ * just pipes raw framed bytes between its own stdio (the browser's native
+ * host pipe) and the singleton's control socket, so the singleton can treat
+ * either connection kind identically.
+ */
+export async function runRelay(): Promise<void> {
+	return new Promise((resolve) => {
+		Bun.connect({
+			unix: platform.controlSocketPath,
+			socket: {
+				open(socket) {
+					process.stdin.on("data", (chunk: Buffer) => {
+						socket.write(chunk);
+					});
+					process.stdin.on("close", () => {
+						socket.end();
+					});
+				},
+				data(_socket, chunk) {
+					process.stdout.write(chunk);
+				},
+				close() {
+					resolve();
+				},
+				error(_socket, error) {
+					console.error("rango daemon: relay connection error", error);
+					resolve();
+				},
+			},
+		}).catch((error: unknown) => {
+			console.error("rango daemon: failed to connect relay", error);
+			resolve();
+		});
+	});
+}

--- a/native-messaging/com.rango.daemon.chrome.json
+++ b/native-messaging/com.rango.daemon.chrome.json
@@ -1,0 +1,7 @@
+{
+	"name": "com.rango.daemon",
+	"description": "Rango CLI daemon bridge",
+	"path": "__DAEMON_PATH__",
+	"type": "stdio",
+	"allowed_origins": ["chrome-extension://__EXTENSION_ID__/"]
+}

--- a/native-messaging/com.rango.daemon.firefox.json
+++ b/native-messaging/com.rango.daemon.firefox.json
@@ -1,0 +1,7 @@
+{
+	"name": "com.rango.daemon",
+	"description": "Rango CLI daemon bridge",
+	"path": "__DAEMON_PATH__",
+	"type": "stdio",
+	"allowed_extensions": ["rango@david-tejada"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 				"@parcel/optimizer-terser": "2.13.3",
 				"@parcel/transformer-inline-string": "2.13.3",
 				"@sindresorhus/tsconfig": "^2.0.0",
+				"@types/bun": "^1.3.14",
 				"@types/chrome": "^0.1.0",
 				"@types/color": "^4.0.0",
 				"@types/combinations": "^1.0.0",
@@ -5095,6 +5096,16 @@
 				"@babel/types": "^7.28.2"
 			}
 		},
+		"node_modules/@types/bun": {
+			"version": "1.3.14",
+			"resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+			"integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bun-types": "1.3.14"
+			}
+		},
 		"node_modules/@types/chrome": {
 			"version": "0.1.39",
 			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.39.tgz",
@@ -7194,6 +7205,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/bun-types": {
+			"version": "1.3.14",
+			"resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+			"integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/bundle-name": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"start:chrome": "web-ext run --source-dir dist/chrome --target chromium",
 		"build-and-package": "run-s build package",
 		"check-types": "tsc --noemit",
+		"check-types:daemon": "tsc --noemit -p tsconfig.bun.json",
 		"check-format": "prettier --check .",
 		"unused-exports": "ts-unused-exports ./tsconfig.json",
 		"lint:css": "stylelint src/**/*.css",
@@ -25,7 +26,11 @@
 		"lint": "run-p lint:* check-types",
 		"lint-fix": "run-p 'lint:* -- --fix'",
 		"pretest": "cross-env NODE_ENV=test run-p lint unused-exports build:chrome",
-		"test": "jest --runInBand"
+		"test": "jest --runInBand",
+		"daemon": "bun run daemon/index.ts --standalone",
+		"cli": "bun run cli/index.ts",
+		"test:daemon": "bun test daemon cli shared",
+		"install-native-host": "scripts/install-native-host.sh"
 	},
 	"browserslist": [
 		"last 1 Chrome version",
@@ -58,6 +63,7 @@
 		"@parcel/optimizer-terser": "2.13.3",
 		"@parcel/transformer-inline-string": "2.13.3",
 		"@sindresorhus/tsconfig": "^2.0.0",
+		"@types/bun": "^1.3.14",
 		"@types/chrome": "^0.1.0",
 		"@types/color": "^4.0.0",
 		"@types/combinations": "^1.0.0",

--- a/scripts/install-native-host.sh
+++ b/scripts/install-native-host.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Registers the rango daemon as a native-messaging host for Chrome and/or
+# Firefox, so the extension's background script can `connectNative()` to it.
+#
+# Usage:
+#   scripts/install-native-host.sh --chrome-extension-id <id> [--browser chrome|firefox|all]
+#
+# Chrome requires the unpacked/installed extension's exact ID up front (it's
+# random for unpacked dev builds unless the manifest pins a "key"); Firefox
+# doesn't, since its manifest already declares a fixed
+# browser_specific_settings.gecko.id ("rango@david-tejada").
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BROWSER="all"
+CHROME_EXTENSION_ID=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--browser)
+		BROWSER="$2"
+		shift 2
+		;;
+	--chrome-extension-id)
+		CHROME_EXTENSION_ID="$2"
+		shift 2
+		;;
+	*)
+		echo "Unknown argument: $1" >&2
+		exit 1
+		;;
+	esac
+done
+
+DAEMON_PATH="$ROOT/daemon/index.ts"
+
+install_manifest() {
+	local template="$1"
+	local dest_dir="$2"
+	local generated="$3"
+
+	sed -e "s|__DAEMON_PATH__|$DAEMON_PATH|g" \
+		-e "s|__EXTENSION_ID__|$CHROME_EXTENSION_ID|g" \
+		"$template" >"$generated"
+
+	mkdir -p "$dest_dir"
+	cp "$generated" "$dest_dir/com.rango.daemon.json"
+	echo "Installed $dest_dir/com.rango.daemon.json"
+}
+
+chrome_dirs() {
+	case "$(uname -s)" in
+	Darwin)
+		echo "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+		;;
+	Linux)
+		echo "$HOME/.config/google-chrome/NativeMessagingHosts"
+		;;
+	*)
+		echo "Unsupported OS for Chrome native messaging install: $(uname -s)" >&2
+		return 1
+		;;
+	esac
+}
+
+firefox_dirs() {
+	case "$(uname -s)" in
+	Darwin)
+		echo "$HOME/Library/Application Support/Mozilla/NativeMessagingHosts"
+		;;
+	Linux)
+		echo "$HOME/.mozilla/native-messaging-hosts"
+		;;
+	*)
+		echo "Unsupported OS for Firefox native messaging install: $(uname -s)" >&2
+		return 1
+		;;
+	esac
+}
+
+mkdir -p "$ROOT/native-messaging/.generated"
+
+if [[ "$BROWSER" == "chrome" || "$BROWSER" == "all" ]]; then
+	if [[ -z "$CHROME_EXTENSION_ID" ]]; then
+		echo "Pass --chrome-extension-id <id> to install the Chrome host (find it at chrome://extensions with Developer Mode on)." >&2
+		exit 1
+	fi
+
+	install_manifest \
+		"$ROOT/native-messaging/com.rango.daemon.chrome.json" \
+		"$(chrome_dirs)" \
+		"$ROOT/native-messaging/.generated/com.rango.daemon.chrome.json"
+fi
+
+if [[ "$BROWSER" == "firefox" || "$BROWSER" == "all" ]]; then
+	install_manifest \
+		"$ROOT/native-messaging/com.rango.daemon.firefox.json" \
+		"$(firefox_dirs)" \
+		"$ROOT/native-messaging/.generated/com.rango.daemon.firefox.json"
+fi

--- a/shared/frame.test.ts
+++ b/shared/frame.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { encodeFrame, FrameDecoder } from "./frame";
+
+describe("encodeFrame / FrameDecoder", () => {
+	test("round-trips a single message", () => {
+		const decoder = new FrameDecoder();
+		const frame = encodeFrame({ id: "1", action: { name: "clickElement" } });
+		const messages = decoder.push(frame);
+
+		expect(messages).toEqual([{ id: "1", action: { name: "clickElement" } }]);
+	});
+
+	test("decodes multiple messages arriving in one chunk", () => {
+		const decoder = new FrameDecoder();
+		const combined = Buffer.concat([
+			Buffer.from(encodeFrame({ n: 1 })),
+			Buffer.from(encodeFrame({ n: 2 })),
+		]);
+
+		expect(decoder.push(combined)).toEqual([{ n: 1 }, { n: 2 }]);
+	});
+
+	test("decodes a message split across multiple chunks", () => {
+		const decoder = new FrameDecoder();
+		const frame = Buffer.from(encodeFrame({ hello: "world" }));
+
+		expect(decoder.push(frame.subarray(0, 3))).toEqual([]);
+		expect(decoder.push(frame.subarray(3, 6))).toEqual([]);
+		expect(decoder.push(frame.subarray(6))).toEqual([{ hello: "world" }]);
+	});
+
+	test("holds a partial trailing message until the rest arrives", () => {
+		const decoder = new FrameDecoder();
+		const first = Buffer.from(encodeFrame({ n: 1 }));
+		const second = Buffer.from(encodeFrame({ n: 2 }));
+
+		expect(decoder.push(Buffer.concat([first, second.subarray(0, 2)]))).toEqual(
+			[{ n: 1 }]
+		);
+		expect(decoder.push(second.subarray(2))).toEqual([{ n: 2 }]);
+	});
+});

--- a/shared/frame.ts
+++ b/shared/frame.ts
@@ -1,0 +1,34 @@
+/**
+ * 4-byte little-endian length prefix + UTF-8 JSON, matching the wire format
+ * Chrome/Firefox require for native-messaging host stdio. Both the daemon's
+ * control socket (singleton <-> relay) and its stdio (singleton <-> browser)
+ * use this same framing so bytes can be piped between them verbatim.
+ */
+export function encodeFrame(payload: unknown): Uint8Array {
+	const json = Buffer.from(JSON.stringify(payload), "utf8");
+	const header = Buffer.alloc(4);
+	header.writeUInt32LE(json.byteLength, 0);
+	return Buffer.concat([header, json]);
+}
+
+export class FrameDecoder {
+	private buffer = Buffer.alloc(0);
+
+	/** Feed in newly-received bytes; returns any complete messages found. */
+	push(chunk: Uint8Array): unknown[] {
+		this.buffer = Buffer.concat([this.buffer, Buffer.from(chunk)]);
+		const messages: unknown[] = [];
+
+		for (;;) {
+			if (this.buffer.byteLength < 4) break;
+			const length = this.buffer.readUInt32LE(0);
+			if (this.buffer.byteLength < 4 + length) break;
+
+			const json = this.buffer.subarray(4, 4 + length);
+			messages.push(JSON.parse(json.toString("utf8")));
+			this.buffer = this.buffer.subarray(4 + length);
+		}
+
+		return messages;
+	}
+}

--- a/shared/platform.ts
+++ b/shared/platform.ts
@@ -1,0 +1,22 @@
+import os from "node:os";
+import path from "node:path";
+
+const home = process.env["RANGO_HOME"] ?? path.join(os.homedir(), ".rango");
+
+export const platform = {
+	home,
+	pidFile: path.join(home, "daemon.pid"),
+	portFile: path.join(home, "daemon.port"),
+	controlSocketPath:
+		process.env["RANGO_CONTROL_SOCKET"] ?? path.join(home, "daemon.sock"),
+	logFile: path.join(home, "daemon.log"),
+};
+
+export const REQUEST_TIMEOUT_MS = Number(
+	process.env["RANGO_REQUEST_TIMEOUT_MS"] ?? 15_000
+);
+
+// Chrome's native messaging host protocol has an undocumented but
+// empirically-real ~1MB practical ceiling per message. Mirrors Interceptor's
+// NATIVE_HOST_TO_CHROME_MAX_BYTES guard.
+export const NATIVE_MESSAGE_MAX_BYTES = 1024 * 1024;

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -1,0 +1,45 @@
+/**
+ * Wire protocol between the rango daemon and the extension's native-messaging
+ * leg. Mirrors the request/response shape Rango's clipboard transport already
+ * uses (`action: {name, ...args}` -> `TalonAction[]`), plus an `id` for
+ * request/response correlation, which the single-slot clipboard channel never
+ * needed but a native-messaging port (genuinely concurrent) does.
+ */
+
+export type CommandAction = {
+	name: string;
+	[key: string]: unknown;
+};
+
+export type DaemonToExtensionRequest = {
+	id: string;
+	action: CommandAction;
+};
+
+export type ExtensionToDaemonResponse =
+	| { id: string; success: true; data?: unknown }
+	| { id: string; success: false; error: string };
+
+export function isDaemonRequest(
+	value: unknown
+): value is DaemonToExtensionRequest {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as { id?: unknown }).id === "string" &&
+		typeof (value as { action?: unknown }).action === "object" &&
+		(value as { action?: unknown }).action !== null &&
+		typeof (value as { action: { name?: unknown } }).action.name === "string"
+	);
+}
+
+export function isExtensionResponse(
+	value: unknown
+): value is ExtensionToDaemonResponse {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as { id?: unknown }).id === "string" &&
+		typeof (value as { success?: unknown }).success === "boolean"
+	);
+}

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -11,6 +11,7 @@ import { handleIncomingMessage } from "./messaging/messageHandler";
 import { addMessageListeners } from "./messaging/messageListeners";
 import { sendMessage, sendMessageSafe } from "./messaging/sendMessage";
 import { UnreachableContentScriptError } from "./messaging/UnreachableContentScriptError";
+import { connectNativeHost } from "./nativeMessaging";
 import { toggleKeyboardClicking } from "./settings/keyboardClicking";
 import { trackRecentTabs } from "./tabs/focusPreviousTab";
 import { setTabLastSounded } from "./tabs/focusTabBySound";
@@ -44,6 +45,16 @@ try {
 // =============================================================================
 if (process.env["NODE_ENV"] === "test") {
 	addEventListener("handle-test-request", handleIncomingCommand);
+}
+
+// =============================================================================
+// CLI TRANSPORT (NATIVE MESSAGING)
+// =============================================================================
+// Safari uses a different native-messaging API (NSExtensionRequest, not the
+// stdio host protocol Chrome/Firefox use), so the CLI daemon bridge is
+// Chrome/Firefox only for now.
+if (process.env.NODE_ENV !== "test" && !isSafari()) {
+	connectNativeHost();
 }
 
 // =============================================================================

--- a/src/background/nativeMessaging/connectNativeHost.ts
+++ b/src/background/nativeMessaging/connectNativeHost.ts
@@ -1,0 +1,52 @@
+import browser, { type Runtime } from "webextension-polyfill";
+import { handleNativeCommand, isIncomingRequest } from "./handleNativeCommand";
+import { safePortPost } from "./safePortPost";
+
+const nativeHostName = "com.rango.daemon";
+const reconnectBaseDelayMs = 1000;
+const reconnectMaxDelayMs = 30_000;
+
+let port: Runtime.Port | undefined;
+let reconnectAttempt = 0;
+let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * Connects to the rango daemon over native messaging (Chrome and Firefox
+ * both support `connectNative`), replacing the clipboard poll as the CLI's
+ * transport into `handleCommand()`. If the native host isn't registered
+ * (e.g. the daemon was never installed, or we're on Safari, which uses a
+ * different native-messaging API) this fails silently — the clipboard/Talon
+ * transport keeps working either way.
+ */
+export function connectNativeHost() {
+	try {
+		port = browser.runtime.connectNative(nativeHostName);
+	} catch (error) {
+		console.warn("Rango: native messaging unavailable.", error);
+		return;
+	}
+
+	port.onMessage.addListener(async (message: unknown) => {
+		if (!isIncomingRequest(message)) return;
+		const response = await handleNativeCommand(message);
+		safePortPost(port, response);
+	});
+
+	port.onDisconnect.addListener(() => {
+		port = undefined;
+		scheduleReconnect();
+	});
+
+	reconnectAttempt = 0;
+}
+
+function scheduleReconnect() {
+	const delay = Math.min(
+		reconnectBaseDelayMs * 2 ** reconnectAttempt,
+		reconnectMaxDelayMs
+	);
+	reconnectAttempt += 1;
+
+	clearTimeout(reconnectTimer);
+	reconnectTimer = setTimeout(connectNativeHost, delay);
+}

--- a/src/background/nativeMessaging/handleNativeCommand.ts
+++ b/src/background/nativeMessaging/handleNativeCommand.ts
@@ -1,0 +1,56 @@
+import type { ActionMap } from "../../typings/Action";
+import { handleCommand } from "../commands/commandHandler";
+import { UnreachableContentScriptError } from "../messaging/UnreachableContentScriptError";
+
+export type IncomingRequest = {
+	id: string;
+	action: { [key: string]: unknown; name: string };
+};
+
+export type OutgoingResponse =
+	| { id: string; success: true; data?: unknown }
+	| { id: string; success: false; error: string };
+
+export function isIncomingRequest(value: unknown): value is IncomingRequest {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as { id?: unknown }).id === "string" &&
+		typeof (value as { action?: unknown }).action === "object" &&
+		(value as { action?: unknown }).action !== null &&
+		typeof (value as { action: { name?: unknown } }).action.name === "string"
+	);
+}
+
+/**
+ * Bridges a native-messaging request into Rango's existing command
+ * dispatcher — the same `handleCommand()` the clipboard/Talon transport
+ * already uses — and translates the result back into the daemon's response
+ * envelope instead of a clipboard-written `TalonAction[]`.
+ */
+export async function handleNativeCommand(
+	request: IncomingRequest
+): Promise<OutgoingResponse> {
+	const { id, action } = request;
+	const { name, ...args } = action;
+
+	try {
+		const result = await handleCommand(
+			name as keyof ActionMap,
+			args as ActionMap[keyof ActionMap]
+		);
+
+		if (result === "noResponse") return { id, success: true };
+		return { id, success: true, data: result };
+	} catch (error: unknown) {
+		if (error instanceof UnreachableContentScriptError) {
+			return { id, success: false, error: error.message };
+		}
+
+		return {
+			id,
+			success: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}

--- a/src/background/nativeMessaging/index.ts
+++ b/src/background/nativeMessaging/index.ts
@@ -1,0 +1,1 @@
+export { connectNativeHost } from "./connectNativeHost";

--- a/src/background/nativeMessaging/safePortPost.ts
+++ b/src/background/nativeMessaging/safePortPost.ts
@@ -1,0 +1,30 @@
+/**
+ * `Port.postMessage()` throws synchronously if the port already disconnected,
+ * but `onDisconnect` fires asynchronously — there's a race window where the
+ * port reference is truthy but posting to it throws anyway. Ported from
+ * Interceptor's `safe-port-post.ts`, which exists for exactly this reason.
+ */
+export function safePortPost(
+	port:
+		| { disconnect?: () => void; postMessage(message: unknown): void }
+		| undefined,
+	message: unknown
+): { posted: boolean; error?: string } {
+	if (!port) return { posted: false, error: "no port" };
+
+	try {
+		port.postMessage(message);
+		return { posted: true };
+	} catch (error) {
+		try {
+			port.disconnect?.();
+		} catch {
+			// Already gone.
+		}
+
+		return {
+			posted: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}

--- a/src/manifests/chrome/manifest.json
+++ b/src/manifests/chrome/manifest.json
@@ -19,7 +19,8 @@
 		"webNavigation",
 		"offscreen",
 		"contextMenus",
-		"bookmarks"
+		"bookmarks",
+		"nativeMessaging"
 	],
 	"content_scripts": [
 		{

--- a/src/manifests/firefox/manifest.json
+++ b/src/manifests/firefox/manifest.json
@@ -23,7 +23,8 @@
 		"notifications",
 		"webNavigation",
 		"contextMenus",
-		"bookmarks"
+		"bookmarks",
+		"nativeMessaging"
 	],
 	"content_scripts": [
 		{

--- a/tsconfig.bun.json
+++ b/tsconfig.bun.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"types": ["bun"]
+	},
+	"include": ["daemon", "cli", "shared"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,6 @@
 		"lib": ["es2023", "DOM", "DOM.Iterable"],
 		"jsx": "react-jsx",
 		"noErrorTruncation": true
-	}
+	},
+	"exclude": ["node_modules", "dist", "daemon", "cli", "shared"]
 }


### PR DESCRIPTION
## Summary

Adds a CLI transport leg that drives Rango's keyboard-hint navigation from the command line, via a host companion daemon that bridges HTTP (the CLI leg) to native messaging (the extension leg). Mirrors the architecture of the sibling `Interceptor` project.

- `daemon/` — Bun-based host companion daemon: `GET /health`, `POST /command` HTTP API, bridged to the extension over Chrome/Firefox's native-messaging stdio protocol. Implements the same PID-file + control-socket singleton/relay election as Interceptor, so multiple browser windows can each spawn a native-messaging host process while only one does protocol work.
- `cli/` — `rango-cli` binary (`status`, `hints show|hide`, `click <label>`, `navigate <label>`), auto-spawning the daemon and reusing Rango's existing `ActionMap` verbs (`enableHints`, `refreshHints`, `disableHints`, `clickElement`) through the existing `handleCommand()` dispatcher — no new command types added.
- `shared/` — wire protocol, frame codec, shared paths.
- `src/background/nativeMessaging/` — extension-side `connectNative()` wiring with exponential-backoff reconnect, bridging native-messaging requests into `handleCommand()` alongside the existing clipboard/Talon transport.

## Scope

- **Browsers**: Chrome + Firefox only. Safari uses a different native-messaging API (`NSExtensionRequest`, not stdio) and is untouched — `connectNativeHost()` is gated behind `!isSafari()`.
- **Hint visibility**: temporary overlay via the existing rendering-coupled `Hint.ts` (`enableHints({level: "now"})`), not a headless hint-computation path. Headless is out of scope for this MVP.

## Testing

- Unit tests: frame codec (partial/split-chunk framing), pending-request correlation/timeout, extension bridge, daemon lifecycle (PID/port files, singleton detection).
- Integration tests: spawn the real `daemon/index.ts --standalone` and `cli/index.ts` binaries as subprocesses and drive the full HTTP → daemon → control-socket round trip against a mock extension socket, since no live browser is available in CI. Run via `npm run test:daemon` / `bun test daemon cli shared`.
- Typechecking: the daemon/cli/shared code uses a separate `tsconfig.bun.json` (Bun globals, top-level `await`) excluded from the root `tsconfig.json`; both typecheck cleanly (`npm run check-types` / `npm run check-types:daemon`).
- All 70 pre-existing Jest unit tests still pass.

See `AGENTS.md` for a fuller writeup of the singleton/relay design and why it's structured this way.

## Not done here

- Live-browser verification of `connectNativeHost()` against real Chrome/Firefox (native-messaging manifest install scripts are included at `native-messaging/` + `scripts/install-native-host.sh`, but CI can't drive a live browser, per the acceptance criteria's own allowance to mock the extension leg).
- Headless hint computation (separate follow-up).
- Safari support.